### PR TITLE
Feature: run tests in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## Unreleased
+
+### Parallel Execution
+
+- perf: add persistent build workers for parallel `ast run` and `ast test` so AssemblyScript modules stay warm across file builds instead of spawning a fresh compiler process per build.
+- perf: make each queue worker own one file through all selected modes before releasing its slot, which removes mid-file mode interleaving across workers.
+- fix: keep parallel mixed-mode builds correct by isolating long-lived compiler workers by build signature so WASI and bindings state does not leak between builds.
+- fix: make `--jobs`, `--build-jobs`, and `--run-jobs` cooperate with ordered queue reporting while still emitting final per-file results as each file completes.
+
 ## 2026-03-25 - v1.0.2
 
 ### Explicit Imports, Typings & Reporting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 ### Parallel Execution
 
 - perf: add persistent build workers for parallel `ast run` and `ast test` so AssemblyScript modules stay warm across file builds instead of spawning a fresh compiler process per build.
+- perf: route normal and single-build-worker builds through the same persistent compiler-worker path so serial `ast test`, `ast run`, and `ast fuzz` runs also reuse the AssemblyScript API instead of spawning a fresh `asc` process per file.
 - perf: make each queue worker own one file through all selected modes before releasing its slot, which removes mid-file mode interleaving across workers.
+- feat: add `--parallel` with an automatic worker heuristic that stays in the 2-4 worker range for typical suites and only grows past that when there are substantially more files to process.
 - fix: keep parallel mixed-mode builds correct by isolating long-lived compiler workers by build signature so WASI and bindings state does not leak between builds.
 - fix: make `--jobs`, `--build-jobs`, and `--run-jobs` cooperate with ordered queue reporting while still emitting final per-file results as each file completes.
 

--- a/bin/build-worker-pool.js
+++ b/bin/build-worker-pool.js
@@ -1,0 +1,149 @@
+import { spawn } from "child_process";
+import { fileURLToPath } from "url";
+export class BuildWorkerPool {
+    constructor(size) {
+        this.pools = new Map();
+        this.nextId = 1;
+        this.closed = false;
+        this.size = Math.max(1, size);
+    }
+    buildFileMode(args) {
+        if (this.closed) {
+            return Promise.reject(new Error("build worker pool is closed"));
+        }
+        const featureToggles = args.featureToggles ?? {};
+        const overrides = args.overrides ?? {};
+        const signature = buildSignature(args.modeName, featureToggles, overrides);
+        const pool = this.getPool(signature);
+        return new Promise((resolve, reject) => {
+            pool.queue.push({
+                id: this.nextId++,
+                configPath: args.configPath,
+                file: args.file,
+                modeName: args.modeName,
+                featureToggles,
+                overrides,
+                resolve,
+                reject,
+            });
+            this.pump(pool);
+        });
+    }
+    async close() {
+        this.closed = true;
+        const waits = [];
+        for (const pool of this.pools.values()) {
+            while (pool.queue.length) {
+                const task = pool.queue.shift();
+                task.reject(new Error("build worker pool closed"));
+            }
+            for (const worker of pool.workers) {
+                waits.push(new Promise((resolve) => {
+                    if (worker.child.exitCode != null || worker.child.killed) {
+                        resolve();
+                        return;
+                    }
+                    worker.child.once("exit", () => resolve());
+                    worker.child.kill();
+                }));
+            }
+        }
+        await Promise.all(waits);
+    }
+    getPool(signature) {
+        let pool = this.pools.get(signature);
+        if (pool)
+            return pool;
+        pool = {
+            workers: Array.from({ length: this.size }, () => this.spawnWorker(signature)),
+            queue: [],
+        };
+        this.pools.set(signature, pool);
+        return pool;
+    }
+    spawnWorker(signature) {
+        const workerPath = fileURLToPath(new URL("./build-worker.js", import.meta.url));
+        const child = spawn(process.execPath, [workerPath], {
+            stdio: ["ignore", "ignore", "ignore", "ipc"],
+        });
+        const worker = {
+            child,
+            busy: false,
+            task: null,
+        };
+        child.on("message", (message) => {
+            this.onMessage(signature, worker, message);
+        });
+        child.on("exit", () => {
+            const pool = this.pools.get(signature);
+            const failedTask = worker.task;
+            worker.busy = false;
+            worker.task = null;
+            if (failedTask) {
+                failedTask.reject(new Error("build worker exited unexpectedly"));
+            }
+            if (!pool || this.closed)
+                return;
+            const index = pool.workers.indexOf(worker);
+            if (index >= 0) {
+                pool.workers[index] = this.spawnWorker(signature);
+            }
+            this.pump(pool);
+        });
+        return worker;
+    }
+    onMessage(signature, worker, message) {
+        const pool = this.pools.get(signature);
+        const task = worker.task;
+        if (!pool || !task || task.id !== message.id)
+            return;
+        worker.busy = false;
+        worker.task = null;
+        if (message.type == "done") {
+            task.resolve();
+        }
+        else {
+            task.reject(deserializeError(message.error));
+        }
+        this.pump(pool);
+    }
+    pump(pool) {
+        for (const worker of pool.workers) {
+            if (worker.busy)
+                continue;
+            const task = pool.queue.shift();
+            if (!task)
+                return;
+            worker.busy = true;
+            worker.task = task;
+            worker.child.send({
+                type: "build-file",
+                id: task.id,
+                configPath: task.configPath,
+                file: task.file,
+                modeName: task.modeName,
+                featureToggles: task.featureToggles,
+                overrides: task.overrides,
+            });
+        }
+    }
+}
+function buildSignature(modeName, featureToggles, overrides) {
+    return JSON.stringify({
+        modeName: modeName ?? "default",
+        featureToggles,
+        overrides,
+    });
+}
+function deserializeError(payload) {
+    const error = new Error(typeof payload.message == "string" ? payload.message : "unknown error");
+    error.name = typeof payload.name == "string" ? payload.name : "Error";
+    if (typeof payload.stack == "string")
+        error.stack = payload.stack;
+    for (const [key, value] of Object.entries(payload)) {
+        if (key == "name" || key == "message" || key == "stack")
+            continue;
+        error[key] = value;
+    }
+    return error;
+}

--- a/bin/build-worker.js
+++ b/bin/build-worker.js
@@ -1,4 +1,4 @@
-import { build, } from "./commands/build-core.js";
+import { build } from "./commands/build-core.js";
 process.env.AS_TEST_BUILD_API = "1";
 process.on("message", async (message) => {
     if (!message || message.type != "build-file")

--- a/bin/build-worker.js
+++ b/bin/build-worker.js
@@ -1,0 +1,43 @@
+import { build, } from "./commands/build-core.js";
+process.env.AS_TEST_BUILD_API = "1";
+process.on("message", async (message) => {
+    if (!message || message.type != "build-file")
+        return;
+    try {
+        await build(message.configPath, [message.file], message.modeName, message.featureToggles, message.overrides);
+        send({
+            type: "done",
+            id: message.id,
+        });
+    }
+    catch (error) {
+        send({
+            type: "error",
+            id: message.id,
+            error: serializeError(error),
+        });
+    }
+});
+function send(message) {
+    if (!process.send)
+        return;
+    process.send(message);
+}
+function serializeError(error) {
+    if (!(error instanceof Error)) {
+        return {
+            name: "Error",
+            message: typeof error == "string" ? error : "unknown error",
+        };
+    }
+    const out = {
+        name: error.name,
+        message: error.message,
+        stack: error.stack,
+    };
+    const errorRecord = error;
+    for (const key of Object.keys(error)) {
+        out[key] = errorRecord[key];
+    }
+    return out;
+}

--- a/bin/commands/build-core.js
+++ b/bin/commands/build-core.js
@@ -1,8 +1,9 @@
 import { existsSync } from "fs";
 import { glob } from "glob";
 import chalk from "chalk";
-import { spawnSync } from "child_process";
+import { spawn } from "child_process";
 import * as path from "path";
+import { createMemoryStream, main as ascMain, } from "assemblyscript/dist/asc.js";
 import { applyMode, getPkgRunner, loadConfig, tokenizeCommand, resolveProjectModule, } from "../util.js";
 import { persistCrashRecord } from "../crash-store.js";
 const DEFAULT_CONFIG_PATH = path.join(process.cwd(), "./as-test.config.json");
@@ -46,7 +47,7 @@ export async function build(configPath = DEFAULT_CONFIG_PATH, selectors = [], mo
         const outFile = `${config.outDir}/${resolveArtifactFileName(file, config.buildOptions.target, modeName, duplicateSpecBasenames)}`;
         const invocation = getBuildCommand(config, pkgRunner, file, outFile, modeName, featureToggles);
         try {
-            buildFile(invocation, buildEnv);
+            await buildFile(invocation, buildEnv);
         }
         catch (error) {
             const modeLabel = modeName ?? "default";
@@ -119,6 +120,7 @@ function getBuildCommand(config, pkgRunner, file, outFile, modeName, featureTogg
     return {
         command: ascInvocation.command,
         args,
+        apiArgs: args.slice(1),
     };
 }
 function resolveAscInvocation(pkgRunner) {
@@ -260,22 +262,96 @@ function ensureDeps(config) {
         }
     }
 }
-function buildFile(invocation, env) {
-    const result = spawnSync(invocation.command, invocation.args, {
-        stdio: ["ignore", "pipe", "pipe"],
-        encoding: "utf8",
-        env,
-        shell: false,
+async function buildFile(invocation, env) {
+    if (process.env.AS_TEST_BUILD_API == "1" && invocation.apiArgs?.length) {
+        await buildFileViaApi(invocation.apiArgs, env);
+        return;
+    }
+    await buildFileViaSpawn(invocation, env);
+}
+async function buildFileViaApi(args, env) {
+    const stdoutChunks = [];
+    const stderrChunks = [];
+    const stdout = createMemoryStream((chunk) => {
+        stdoutChunks.push(typeof chunk == "string" ? chunk : Buffer.from(chunk).toString("utf8"));
     });
-    if (result.error)
-        throw result.error;
-    if (result.status !== 0) {
-        const error = new Error(result.stderr?.trim() ||
-            result.stdout?.trim() ||
-            `command exited with code ${result.status}`);
-        error.stderr = result.stderr ?? "";
-        error.stdout = result.stdout ?? "";
-        throw error;
+    const stderr = createMemoryStream((chunk) => {
+        stderrChunks.push(typeof chunk == "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+    });
+    const previousEnv = snapshotEnv();
+    applyEnv(env);
+    try {
+        const result = await ascMain(args, { stdout, stderr });
+        if (result.error) {
+            const error = result.error;
+            error.stderr = stderrChunks.join("").trim();
+            error.stdout = stdoutChunks.join("").trim();
+            throw error;
+        }
+    }
+    finally {
+        restoreEnv(previousEnv);
+    }
+}
+async function buildFileViaSpawn(invocation, env) {
+    await new Promise((resolve, reject) => {
+        const child = spawn(invocation.command, invocation.args, {
+            stdio: ["ignore", "pipe", "pipe"],
+            env,
+            shell: false,
+        });
+        let stdout = "";
+        let stderr = "";
+        child.stdout?.on("data", (chunk) => {
+            stdout += chunk.toString();
+        });
+        child.stderr?.on("data", (chunk) => {
+            stderr += chunk.toString();
+        });
+        child.on("error", reject);
+        child.on("close", (code) => {
+            if (code === 0) {
+                resolve();
+                return;
+            }
+            const error = new Error(stderr.trim() || stdout.trim() || `command exited with code ${code}`);
+            error.stderr = stderr.trim();
+            error.stdout = stdout.trim();
+            reject(error);
+        });
+    });
+}
+function snapshotEnv() {
+    return { ...process.env };
+}
+function applyEnv(nextEnv) {
+    const keys = new Set([
+        ...Object.keys(process.env),
+        ...Object.keys(nextEnv),
+    ]);
+    for (const key of keys) {
+        const value = nextEnv[key];
+        if (value == undefined) {
+            delete process.env[key];
+        }
+        else {
+            process.env[key] = value;
+        }
+    }
+}
+function restoreEnv(previousEnv) {
+    const keys = new Set([
+        ...Object.keys(process.env),
+        ...Object.keys(previousEnv),
+    ]);
+    for (const key of keys) {
+        const value = previousEnv[key];
+        if (value == undefined) {
+            delete process.env[key];
+        }
+        else {
+            process.env[key] = value;
+        }
     }
 }
 function formatInvocation(invocation) {

--- a/bin/commands/build-core.js
+++ b/bin/commands/build-core.js
@@ -6,6 +6,7 @@ import * as path from "path";
 import { createMemoryStream, main as ascMain, } from "assemblyscript/dist/asc.js";
 import { applyMode, getPkgRunner, loadConfig, tokenizeCommand, resolveProjectModule, } from "../util.js";
 import { persistCrashRecord } from "../crash-store.js";
+import { BuildWorkerPool } from "../build-worker-pool.js";
 const DEFAULT_CONFIG_PATH = path.join(process.cwd(), "./as-test.config.json");
 class BuildFailureError extends Error {
     constructor(args) {
@@ -43,6 +44,19 @@ export async function build(configPath = DEFAULT_CONFIG_PATH, selectors = [], mo
         ...config.buildOptions.env,
         AS_TEST_COVERAGE_ENABLED: coverageEnabled ? "1" : "0",
     };
+    if (!process.env.AS_TEST_BUILD_API && !hasCustomBuildCommand(config)) {
+        const pool = getSerialBuildWorkerPool();
+        for (const file of inputFiles) {
+            await pool.buildFileMode({
+                configPath,
+                file,
+                modeName,
+                featureToggles,
+                overrides,
+            });
+        }
+        return;
+    }
     for (const file of inputFiles) {
         const outFile = `${config.outDir}/${resolveArtifactFileName(file, config.buildOptions.target, modeName, duplicateSpecBasenames)}`;
         const invocation = getBuildCommand(config, pkgRunner, file, outFile, modeName, featureToggles);
@@ -80,6 +94,13 @@ export async function build(configPath = DEFAULT_CONFIG_PATH, selectors = [], mo
             });
         }
     }
+}
+let serialBuildWorkerPool = null;
+function getSerialBuildWorkerPool() {
+    if (!serialBuildWorkerPool) {
+        serialBuildWorkerPool = new BuildWorkerPool(1);
+    }
+    return serialBuildWorkerPool;
 }
 export async function getBuildInvocationPreview(configPath = DEFAULT_CONFIG_PATH, file, modeName, featureToggles = {}, overrides = {}) {
     const loadedConfig = loadConfig(configPath, false);

--- a/bin/commands/fuzz-core.js
+++ b/bin/commands/fuzz-core.js
@@ -20,8 +20,11 @@ export async function fuzz(configPath = DEFAULT_CONFIG_PATH, selectors = [], mod
     const duplicateBasenames = resolveDuplicateBasenames(inputFiles);
     const results = [];
     for (const file of inputFiles) {
+        const buildStartedAt = Date.now();
         await build(configPath, [file], modeName, { coverage: false }, { target: "bindings", args: ["--use", "AS_TEST_FUZZ=1"], kind: "fuzz" });
-        results.push(await runFuzzTarget(file, mode.config.outDir, duplicateBasenames, config, modeName));
+        const buildFinishedAt = Date.now();
+        const buildTime = buildFinishedAt - buildStartedAt;
+        results.push(await runFuzzTarget(file, mode.config.outDir, duplicateBasenames, config, buildStartedAt, buildFinishedAt, buildTime, modeName));
     }
     return results;
 }
@@ -32,7 +35,7 @@ function resolveFuzzConfig(raw, overrides) {
     }
     return config;
 }
-async function runFuzzTarget(file, outDir, duplicateBasenames, config, modeName) {
+async function runFuzzTarget(file, outDir, duplicateBasenames, config, buildStartedAt, buildFinishedAt, buildTime, modeName) {
     const startedAt = Date.now();
     const artifact = resolveArtifactFileName(file, duplicateBasenames, modeName);
     const wasmPath = path.resolve(process.cwd(), outDir, artifact);
@@ -80,6 +83,9 @@ async function runFuzzTarget(file, outDir, duplicateBasenames, config, modeName)
             crashFiles: [crash.jsonPath],
             seed: config.seed,
             time: Date.now() - startedAt,
+            buildTime,
+            buildStartedAt,
+            buildFinishedAt,
             fuzzers: [],
         };
     }
@@ -103,6 +109,9 @@ async function runFuzzTarget(file, outDir, duplicateBasenames, config, modeName)
             crashFiles: [crash.jsonPath],
             seed: config.seed,
             time: Date.now() - startedAt,
+            buildTime,
+            buildStartedAt,
+            buildFinishedAt,
             fuzzers: [],
         };
     }
@@ -115,6 +124,9 @@ async function runFuzzTarget(file, outDir, duplicateBasenames, config, modeName)
         crashFiles: [],
         seed: config.seed,
         time: Date.now() - startedAt,
+        buildTime,
+        buildStartedAt,
+        buildFinishedAt,
         fuzzers: report.fuzzers,
     };
 }

--- a/bin/commands/init-core.js
+++ b/bin/commands/init-core.js
@@ -529,6 +529,9 @@ function applyInit(root, target, example, fuzzExample, force) {
     if (!scripts.test) {
         scripts.test = "ast test";
     }
+    if (fuzzExample && !scripts.fuzz) {
+        scripts.fuzz = "ast fuzz";
+    }
     if (!pkg.type) {
         pkg.type = "module";
     }
@@ -910,19 +913,17 @@ function resolveInstallCommand(root) {
     return { command: "npm", args: ["install"] };
 }
 function buildMinimalExampleSpec() {
-    return `import { describe, expect, test, run } from "as-test";
+    return `import { describe, expect, test } from "as-test";
 
 describe("example", () => {
   test("adds numbers", () => {
     expect(1 + 2).toBe(3);
   });
 });
-
-run();
 `;
 }
 function buildFullExampleSpec() {
-    return `import { afterAll, beforeAll, describe, expect, it, log, run, test } from "as-test";
+    return `import { afterAll, beforeAll, describe, expect, it, log, test } from "as-test";
 
 beforeAll(() => {
   log("setup");
@@ -952,8 +953,6 @@ describe("strings", () => {
     expect("as-test").toStartWith("as");
   });
 });
-
-run();
 `;
 }
 function buildBasicFuzzerExample() {

--- a/bin/commands/run-core.js
+++ b/bin/commands/run-core.js
@@ -545,6 +545,7 @@ export async function run(flags = {}, configPath = DEFAULT_CONFIG_PATH, selector
             clean: cleanOutput,
             snapshotEnabled,
             showCoverage,
+            buildTime: 0,
             snapshotSummary,
             coverageSummary,
             stats,
@@ -563,6 +564,7 @@ export async function run(flags = {}, configPath = DEFAULT_CONFIG_PATH, selector
     }
     return {
         failed,
+        buildTime: 0,
         stats,
         snapshotSummary,
         coverageSummary,

--- a/bin/commands/run-core.js
+++ b/bin/commands/run-core.js
@@ -1566,15 +1566,18 @@ function mergeVerdict(current, next) {
         return "skip";
     return "none";
 }
-export async function createRunReporter(configPath = DEFAULT_CONFIG_PATH, reporterPath, modeName) {
+export async function createRunReporter(configPath = DEFAULT_CONFIG_PATH, reporterPath, modeName, context = {
+    stdout: process.stdout,
+    stderr: process.stderr,
+}) {
     const resolvedConfigPath = configPath ?? DEFAULT_CONFIG_PATH;
     const loadedConfig = loadConfig(resolvedConfigPath);
     const mode = applyMode(loadedConfig, modeName);
     const config = mode.config;
     const selection = resolveReporterSelection(reporterPath, config.runOptions.reporter);
     const reporter = await loadReporter(selection, resolvedConfigPath, {
-        stdout: process.stdout,
-        stderr: process.stderr,
+        stdout: context.stdout,
+        stderr: context.stderr,
     });
     const runtimeCommand = resolveRuntimeCommand(getConfiguredRuntimeCmd(config), config.buildOptions.target, false);
     return {

--- a/bin/commands/run.js
+++ b/bin/commands/run.js
@@ -10,6 +10,7 @@ export async function executeRunCommand(rawArgs, flags, configPath, selectedMode
         clean: flags.includes("--clean"),
         showCoverage: flags.includes("--show-coverage"),
         verbose: flags.includes("--verbose"),
+        ...deps.resolveParallelJobs(rawArgs, "run"),
         coverage: featureToggles.coverage,
         browser: deps.resolveBrowserOverride(rawArgs, "run"),
     };

--- a/bin/commands/test.js
+++ b/bin/commands/test.js
@@ -13,6 +13,7 @@ export async function executeTestCommand(rawArgs, flags, configPath, selectedMod
         clean: flags.includes("--clean"),
         showCoverage: flags.includes("--show-coverage"),
         verbose: flags.includes("--verbose"),
+        ...deps.resolveParallelJobs(rawArgs, "test"),
         coverage: featureToggles.coverage,
         browser: deps.resolveBrowserOverride(rawArgs, "test"),
     };

--- a/bin/index.js
+++ b/bin/index.js
@@ -15,6 +15,7 @@ import { spawnSync } from "child_process";
 import { glob } from "glob";
 import { createInterface } from "readline";
 import { existsSync } from "fs";
+import { availableParallelism, cpus } from "os";
 import { BuildWorkerPool } from "./build-worker-pool.js";
 const _args = process.argv.slice(2);
 const flags = [];
@@ -193,9 +194,13 @@ function info() {
         "        " +
         "Use chrome, chromium, firefox, webkit, or an executable path for web modes");
     console.log("   " +
+        chalk.bold.blue("--parallel") +
+        "                     " +
+        "Run files through an ordered worker pool using an automatic worker count");
+    console.log("   " +
         chalk.bold.blue("--jobs <n>") +
         "                     " +
-        "Run files through an ordered worker pool");
+        "Run files through an ordered worker pool with an explicit worker count");
     console.log("   " +
         chalk.bold.blue("--build-jobs <n>") +
         "               " +
@@ -305,6 +310,7 @@ function printCommandHelp(command) {
         process.stdout.write("  --config <path>          Use a specific config file\n");
         process.stdout.write("  --mode <name[,name...]>  Run one or multiple named config modes\n");
         process.stdout.write("  --browser <name|path>    Use chrome, chromium, firefox, webkit, or an executable path for web modes\n");
+        process.stdout.write("  --parallel              Run files through an ordered worker pool using an automatic worker count\n");
         process.stdout.write("  --jobs <n>               Run files through an ordered worker pool\n");
         process.stdout.write("  --build-jobs <n>         Limit concurrent build tasks (defaults to --jobs)\n");
         process.stdout.write("  --run-jobs <n>           Limit concurrent run tasks (defaults to --jobs)\n");
@@ -330,6 +336,7 @@ function printCommandHelp(command) {
         process.stdout.write("  --config <path>          Use a specific config file\n");
         process.stdout.write("  --mode <name[,name...]>  Run one or multiple named config modes\n");
         process.stdout.write("  --browser <name|path>    Use chrome, chromium, firefox, webkit, or an executable path for web modes\n");
+        process.stdout.write("  --parallel              Run files through an ordered worker pool using an automatic worker count\n");
         process.stdout.write("  --jobs <n>               Run files through an ordered worker pool\n");
         process.stdout.write("  --build-jobs <n>         Limit concurrent build tasks (defaults to --jobs)\n");
         process.stdout.write("  --run-jobs <n>           Limit concurrent run tasks (defaults to --jobs)\n");
@@ -342,6 +349,7 @@ function printCommandHelp(command) {
         process.stdout.write("  --fuzz                   Run fuzz targets after the normal test pass\n");
         process.stdout.write("  --fuzz-runs <n>          Override fuzz iteration count for this run\n");
         process.stdout.write("  --fuzz-seed <n>          Override fuzz seed for this run\n");
+        process.stdout.write("  --parallel              Run files through an ordered worker pool using an automatic worker count\n");
         process.stdout.write("  --jobs <n>               Run files through an ordered worker pool\n");
         process.stdout.write("  --build-jobs <n>         Limit concurrent build tasks (defaults to --jobs)\n");
         process.stdout.write("  --run-jobs <n>           Limit concurrent run tasks (defaults to --jobs)\n");
@@ -460,6 +468,7 @@ function resolveCommandArgs(rawArgs, command) {
         }
         if (arg == "--runs" ||
             arg == "--seed" ||
+            arg == "--parallel" ||
             arg == "--jobs" ||
             arg == "--build-jobs" ||
             arg == "--run-jobs" ||
@@ -638,11 +647,16 @@ function resolveBrowserOverride(rawArgs, command) {
 }
 function resolveJobs(rawArgs, command) {
     let seenCommand = false;
+    let parallel = false;
     for (let i = 0; i < rawArgs.length; i++) {
         const arg = rawArgs[i];
         if (!seenCommand) {
             if (arg == command)
                 seenCommand = true;
+            continue;
+        }
+        if (arg == "--parallel") {
+            parallel = true;
             continue;
         }
         const parsed = parseNumberFlag(rawArgs, i, "--jobs");
@@ -653,7 +667,7 @@ function resolveJobs(rawArgs, command) {
         }
         return parsed.number;
     }
-    return 1;
+    return parallel ? 0 : 1;
 }
 function resolveParallelJobs(rawArgs, command) {
     const baseJobs = resolveJobs(rawArgs, command);
@@ -718,6 +732,36 @@ function resolveFuzzParallelJobs(rawArgs) {
     }
     const jobs = Math.max(baseJobs, buildJobs, runJobs);
     return { jobs, buildJobs, runJobs };
+}
+function resolveEffectiveParallelJobs(settings, totalFiles) {
+    if (settings.jobs > 0) {
+        return {
+            jobs: Math.max(settings.jobs, settings.buildJobs, settings.runJobs),
+            buildJobs: settings.buildJobs > 0 ? settings.buildJobs : settings.jobs,
+            runJobs: settings.runJobs > 0 ? settings.runJobs : settings.jobs,
+        };
+    }
+    const autoJobs = resolveAutoJobs(totalFiles);
+    return {
+        jobs: Math.max(autoJobs, settings.buildJobs, settings.runJobs),
+        buildJobs: settings.buildJobs > 0 ? settings.buildJobs : autoJobs,
+        runJobs: settings.runJobs > 0 ? settings.runJobs : autoJobs,
+    };
+}
+function resolveAutoJobs(totalFiles) {
+    const cpuCount = typeof availableParallelism == "function"
+        ? availableParallelism()
+        : cpus().length;
+    const cpuBudget = Math.max(1, cpuCount - 1);
+    if (totalFiles <= 1)
+        return 1;
+    if (totalFiles <= 4)
+        return Math.min(2, cpuBudget, totalFiles);
+    if (totalFiles <= 12)
+        return Math.min(3, cpuBudget);
+    if (totalFiles <= 32)
+        return Math.min(4, cpuBudget);
+    return Math.min(Math.max(4, Math.ceil(totalFiles / 12)), cpuBudget);
 }
 function createBufferedStream() {
     const chunks = [];
@@ -902,9 +946,12 @@ async function runTestSequential(runFlags, configPath, selectors, buildFeatureTo
     });
     const results = [];
     let failed = false;
+    const buildIntervals = [];
     const duplicateSpecBasenames = resolveDuplicateSpecBasenames(files);
     for (const file of files) {
+        const buildStartedAt = Date.now();
         await build(configPath, [file], modeName, buildFeatureToggles);
+        buildIntervals.push({ start: buildStartedAt, end: Date.now() });
         const buildInvocation = await getBuildInvocationPreview(configPath, file, modeName, buildFeatureToggles);
         const artifactKey = resolvePerFileArtifactKey(file, duplicateSpecBasenames);
         const result = await run(runFlags, configPath, [file], false, {
@@ -927,6 +974,7 @@ async function runTestSequential(runFlags, configPath, selectors, buildFeatureTo
             clean: runFlags.clean,
             snapshotEnabled,
             showCoverage: runFlags.showCoverage,
+            buildTime: getMergedIntervalDuration(buildIntervals),
             snapshotSummary: summary.snapshotSummary,
             coverageSummary: summary.coverageSummary,
             stats: summary.stats,
@@ -938,6 +986,7 @@ async function runTestSequential(runFlags, configPath, selectors, buildFeatureTo
     return {
         failed,
         summary: {
+            buildTime: getMergedIntervalDuration(buildIntervals),
             snapshotSummary: summary.snapshotSummary,
             coverageSummary: summary.coverageSummary,
             stats: summary.stats,
@@ -954,15 +1003,19 @@ async function runRuntimeModes(runFlags, configPath, selectors, modes) {
     await ensureWebBrowsersReady(configPath, modes, runFlags.browser);
     const modeSummaryTotal = Math.max(modes.length, 1);
     const fileSummaryTotal = await resolveConfiguredFileTotal(configPath);
-    if (runFlags.jobs > 1) {
+    const effectiveRunFlags = {
+        ...runFlags,
+        ...resolveEffectiveParallelJobs(runFlags, fileSummaryTotal),
+    };
+    if (effectiveRunFlags.jobs > 1) {
         if (modes.length > 1) {
-            const failed = await runRuntimeMatrixParallel(runFlags, configPath, selectors, modes, modeSummaryTotal, fileSummaryTotal);
+            const failed = await runRuntimeMatrixParallel(effectiveRunFlags, configPath, selectors, modes, modeSummaryTotal, fileSummaryTotal);
             process.exit(failed ? 1 : 0);
             return;
         }
         let failed = false;
         for (const modeName of modes) {
-            const result = await runRuntimeSingleParallel(runFlags, configPath, selectors, modeName, modeSummaryTotal, fileSummaryTotal);
+            const result = await runRuntimeSingleParallel(effectiveRunFlags, configPath, selectors, modeName, modeSummaryTotal, fileSummaryTotal);
             if (result)
                 failed = true;
         }
@@ -970,14 +1023,14 @@ async function runRuntimeModes(runFlags, configPath, selectors, modes) {
         return;
     }
     if (modes.length > 1) {
-        const failed = await runRuntimeMatrix(runFlags, configPath, selectors, modes, modeSummaryTotal, fileSummaryTotal);
+        const failed = await runRuntimeMatrix(effectiveRunFlags, configPath, selectors, modes, modeSummaryTotal, fileSummaryTotal);
         process.exit(failed ? 1 : 0);
         return;
     }
     let failed = false;
     const buildCommandsByFile = await previewBuildCommands(configPath, selectors, modes[0], {});
     for (const modeName of modes) {
-        const result = await run(runFlags, configPath, selectors, false, {
+        const result = await run(effectiveRunFlags, configPath, selectors, false, {
             modeName,
             modeSummaryTotal,
             modeSummaryExecuted: 1,
@@ -1018,6 +1071,7 @@ async function runRuntimeMatrix(runFlags, configPath, selectors, modes, modeSumm
         passed: false,
     }));
     const duplicateSpecBasenames = resolveDuplicateSpecBasenames(files);
+    const buildIntervals = [];
     for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
         const file = files[fileIndex];
         const fileName = path.basename(file);
@@ -1074,6 +1128,7 @@ async function runRuntimeMatrix(runFlags, configPath, selectors, modes, modeSumm
         clean: runFlags.clean,
         snapshotEnabled,
         showCoverage: runFlags.showCoverage,
+        buildTime: 0,
         snapshotSummary: summary.snapshotSummary,
         coverageSummary: summary.coverageSummary,
         stats: summary.stats,
@@ -1086,15 +1141,19 @@ async function runTestModes(runFlags, configPath, selectors, modes, buildFeature
     await ensureWebBrowsersReady(configPath, modes, runFlags.browser);
     const modeSummaryTotal = Math.max(modes.length, 1);
     const fileSummaryTotal = await resolveConfiguredFileTotal(configPath, selectors);
-    if (runFlags.jobs > 1) {
+    const effectiveRunFlags = {
+        ...runFlags,
+        ...resolveEffectiveParallelJobs(runFlags, fileSummaryTotal),
+    };
+    if (effectiveRunFlags.jobs > 1) {
         if (modes.length > 1) {
-            const failed = await runTestMatrixParallel(runFlags, configPath, selectors, modes, buildFeatureToggles, modeSummaryTotal, fileSummaryTotal, fuzzEnabled, fuzzOverrides);
+            const failed = await runTestMatrixParallel(effectiveRunFlags, configPath, selectors, modes, buildFeatureToggles, modeSummaryTotal, fileSummaryTotal, fuzzEnabled, fuzzOverrides);
             process.exit(failed ? 1 : 0);
             return;
         }
         let failed = false;
         for (const modeName of modes) {
-            const modeFailed = await runTestSingleParallel(runFlags, configPath, selectors, buildFeatureToggles, modeSummaryTotal, fileSummaryTotal, fuzzEnabled, fuzzOverrides, modeName);
+            const modeFailed = await runTestSingleParallel(effectiveRunFlags, configPath, selectors, buildFeatureToggles, modeSummaryTotal, fileSummaryTotal, fuzzEnabled, fuzzOverrides, modeName);
             if (modeFailed)
                 failed = true;
         }
@@ -1102,14 +1161,14 @@ async function runTestModes(runFlags, configPath, selectors, modes, buildFeature
         return;
     }
     if (modes.length > 1) {
-        const failed = await runTestMatrix(runFlags, configPath, selectors, modes, buildFeatureToggles, modeSummaryTotal, fileSummaryTotal, fuzzEnabled, fuzzOverrides);
+        const failed = await runTestMatrix(effectiveRunFlags, configPath, selectors, modes, buildFeatureToggles, modeSummaryTotal, fileSummaryTotal, fuzzEnabled, fuzzOverrides);
         process.exit(failed ? 1 : 0);
         return;
     }
     let failed = false;
     for (const modeName of modes) {
         const reporterSession = await createRunReporter(configPath, undefined, modeName);
-        const modeResult = await runTestSequential(runFlags, configPath, selectors, buildFeatureToggles, modeSummaryTotal, fileSummaryTotal, fuzzEnabled, modeName, reporterSession.reporter, !fuzzEnabled);
+        const modeResult = await runTestSequential(effectiveRunFlags, configPath, selectors, buildFeatureToggles, modeSummaryTotal, fileSummaryTotal, fuzzEnabled, modeName, reporterSession.reporter, !fuzzEnabled);
         if (modeResult.failed)
             failed = true;
         if (fuzzEnabled) {
@@ -1121,8 +1180,10 @@ async function runTestModes(runFlags, configPath, selectors, modes, buildFeature
                 failed = true;
             reporterSession.reporter.onRunComplete?.({
                 clean: runFlags.clean,
-                snapshotEnabled: runFlags.snapshot !== false,
-                showCoverage: runFlags.showCoverage,
+                snapshotEnabled: effectiveRunFlags.snapshot !== false,
+                showCoverage: effectiveRunFlags.showCoverage,
+                buildTime: modeResult.summary.buildTime +
+                    getMergedIntervalDuration(collectFuzzBuildIntervals(fuzzResults)),
                 snapshotSummary: modeResult.summary.snapshotSummary,
                 coverageSummary: modeResult.summary.coverageSummary,
                 stats: modeResult.summary.stats,
@@ -1170,6 +1231,7 @@ async function runTestMatrix(runFlags, configPath, selectors, modes, buildFeatur
         passed: false,
     }));
     const duplicateSpecBasenames = resolveDuplicateSpecBasenames(files);
+    const buildIntervals = [];
     for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
         const file = files[fileIndex];
         const fileName = path.basename(file);
@@ -1181,7 +1243,9 @@ async function runTestMatrix(runFlags, configPath, selectors, modes, buildFeatur
         for (let i = 0; i < modes.length; i++) {
             const modeName = modes[i];
             try {
+                const buildStartedAt = Date.now();
                 await build(configPath, [file], modeName, buildFeatureToggles);
+                buildIntervals.push({ start: buildStartedAt, end: Date.now() });
                 const buildInvocation = await getBuildInvocationPreview(configPath, file, modeName, buildFeatureToggles);
                 const artifactKey = resolvePerFileArtifactKey(file, duplicateSpecBasenames);
                 const result = await run(runFlags, configPath, [file], false, {
@@ -1233,11 +1297,13 @@ async function runTestMatrix(runFlags, configPath, selectors, modes, buildFeatur
         if (fuzzResults.some(hasFuzzFailures))
             failed = true;
         fuzzSummary = summarizeFuzzExecutions(fuzzResults);
+        buildIntervals.push(...collectFuzzBuildIntervals(fuzzResults));
     }
     reporter.onRunComplete?.({
         clean: runFlags.clean,
         snapshotEnabled,
         showCoverage: runFlags.showCoverage,
+        buildTime: getMergedIntervalDuration(buildIntervals),
         snapshotSummary: summary.snapshotSummary,
         coverageSummary: summary.coverageSummary,
         stats: summary.stats,
@@ -1250,8 +1316,10 @@ async function runTestMatrix(runFlags, configPath, selectors, modes, buildFeatur
 }
 async function runFuzzModes(configPath, selectors, modes, rawArgs) {
     const overrides = resolveFuzzOverrides(rawArgs, "fuzz");
-    const { jobs, buildJobs, runJobs } = resolveFuzzParallelJobs(rawArgs);
+    const parallelSettings = resolveFuzzParallelJobs(rawArgs);
     const clean = rawArgs.includes("--clean");
+    const fuzzFiles = await resolveSelectedFuzzFiles(configPath, selectors);
+    const { jobs, buildJobs, runJobs } = resolveEffectiveParallelJobs(parallelSettings, fuzzFiles.length);
     if (jobs > 1) {
         const results = await runFuzzMatrixResultsParallel(configPath, selectors, modes, overrides, jobs, buildJobs, runJobs, clean);
         const reporterSession = await createRunReporter(configPath);
@@ -1310,6 +1378,7 @@ async function runRuntimeSingleParallel(runFlags, configPath, selectors, modeNam
         clean: runFlags.clean,
         snapshotEnabled,
         showCoverage: runFlags.showCoverage,
+        buildTime: 0,
         snapshotSummary: summary.snapshotSummary,
         coverageSummary: summary.coverageSummary,
         stats: summary.stats,
@@ -1342,6 +1411,7 @@ async function runRuntimeMatrixParallel(runFlags, configPath, selectors, modes, 
     const queueDisplay = new ParallelQueueDisplay(!runFlags.clean);
     const poolWidth = Math.max(runFlags.jobs, runFlags.buildJobs, runFlags.runJobs);
     const buildPool = new BuildWorkerPool(runFlags.buildJobs);
+    const buildIntervals = [];
     try {
         await runOrderedPool(files, poolWidth, async (file, fileIndex) => {
             const fileName = path.basename(file);
@@ -1350,11 +1420,13 @@ async function runRuntimeMatrixParallel(runFlags, configPath, selectors, modes, 
             const modeTimes = modes.map(() => "...");
             for (let i = 0; i < modes.length; i++) {
                 const modeName = modes[i];
+                const buildStartedAt = Date.now();
                 await buildPool.buildFileMode({
                     configPath,
                     file,
                     modeName,
                 });
+                buildIntervals.push({ start: buildStartedAt, end: Date.now() });
                 const buildInvocation = await getBuildInvocationPreview(configPath, file, modeName, {});
                 const artifactKey = resolvePerFileArtifactKey(file, duplicateSpecBasenames);
                 const result = await run(runFlags, configPath, [file], false, {
@@ -1403,6 +1475,7 @@ async function runRuntimeMatrixParallel(runFlags, configPath, selectors, modes, 
         clean: runFlags.clean,
         snapshotEnabled,
         showCoverage: runFlags.showCoverage,
+        buildTime: getMergedIntervalDuration(buildIntervals),
         snapshotSummary: summary.snapshotSummary,
         coverageSummary: summary.coverageSummary,
         stats: summary.stats,
@@ -1431,17 +1504,20 @@ async function runTestSingleParallel(runFlags, configPath, selectors, buildFeatu
     const results = new Array(files.length);
     const queueDisplay = new ParallelQueueDisplay(!runFlags.clean);
     const poolWidth = Math.max(runFlags.jobs, runFlags.buildJobs, runFlags.runJobs);
+    const buildIntervals = [];
     if (files.length) {
         const buildPool = new BuildWorkerPool(runFlags.buildJobs);
         try {
             await runOrderedPool(files, poolWidth, async (file, index) => {
                 const token = renderQueuedFileStart(queueDisplay, path.basename(file));
+                const buildStartedAt = Date.now();
                 await buildPool.buildFileMode({
                     configPath,
                     file,
                     modeName,
                     featureToggles: buildFeatureToggles,
                 });
+                buildIntervals.push({ start: buildStartedAt, end: Date.now() });
                 const buildInvocation = await getBuildInvocationPreview(configPath, file, modeName, buildFeatureToggles);
                 const artifactKey = resolvePerFileArtifactKey(file, duplicateSpecBasenames);
                 const buffered = await createBufferedReporter(configPath, modeName);
@@ -1477,11 +1553,13 @@ async function runTestSingleParallel(runFlags, configPath, selectors, buildFeatu
         if (fuzzResults.some(hasFuzzFailures))
             failed = true;
         fuzzSummary = summarizeFuzzExecutions(fuzzResults);
+        buildIntervals.push(...collectFuzzBuildIntervals(fuzzResults));
     }
     reporter.onRunComplete?.({
         clean: runFlags.clean,
         snapshotEnabled,
         showCoverage: runFlags.showCoverage,
+        buildTime: getMergedIntervalDuration(buildIntervals),
         snapshotSummary: summary.snapshotSummary,
         coverageSummary: summary.coverageSummary,
         stats: summary.stats,
@@ -1521,6 +1599,7 @@ async function runTestMatrixParallel(runFlags, configPath, selectors, modes, bui
     const queueDisplay = new ParallelQueueDisplay(!runFlags.clean);
     const poolWidth = Math.max(runFlags.jobs, runFlags.buildJobs, runFlags.runJobs);
     const buildPool = new BuildWorkerPool(runFlags.buildJobs);
+    const buildIntervals = [];
     try {
         await runOrderedPool(files, poolWidth, async (file, fileIndex) => {
             const fileName = path.basename(file);
@@ -1529,12 +1608,14 @@ async function runTestMatrixParallel(runFlags, configPath, selectors, modes, bui
             const modeTimes = modes.map(() => "...");
             for (let i = 0; i < modes.length; i++) {
                 const modeName = modes[i];
+                const buildStartedAt = Date.now();
                 await buildPool.buildFileMode({
                     configPath,
                     file,
                     modeName,
                     featureToggles: buildFeatureToggles,
                 });
+                buildIntervals.push({ start: buildStartedAt, end: Date.now() });
                 const buildInvocation = await getBuildInvocationPreview(configPath, file, modeName, buildFeatureToggles);
                 const artifactKey = resolvePerFileArtifactKey(file, duplicateSpecBasenames);
                 const result = await run(runFlags, configPath, [file], false, {
@@ -1589,11 +1670,13 @@ async function runTestMatrixParallel(runFlags, configPath, selectors, modes, bui
         if (fuzzResults.some(hasFuzzFailures))
             failed = true;
         fuzzSummary = summarizeFuzzExecutions(fuzzResults);
+        buildIntervals.push(...collectFuzzBuildIntervals(fuzzResults));
     }
     reporter.onRunComplete?.({
         clean: runFlags.clean,
         snapshotEnabled,
         showCoverage: runFlags.showCoverage,
+        buildTime: getMergedIntervalDuration(buildIntervals),
         snapshotSummary: summary.snapshotSummary,
         coverageSummary: summary.coverageSummary,
         stats: summary.stats,
@@ -1654,10 +1737,42 @@ function buildFuzzCompleteEvent(results, modes) {
     return {
         results,
         time: results.reduce((sum, item) => sum + item.time, 0),
+        buildTime: getMergedIntervalDuration(collectFuzzBuildIntervals(results)),
         fuzzingSummary: summarizeFuzzExecutions(results),
         suiteSummary: summarizeFuzzSuites(results),
         modeSummary: summarizeFuzzModes(results, modes),
     };
+}
+function collectFuzzBuildIntervals(results) {
+    return results.map((result) => ({
+        start: result.buildStartedAt,
+        end: result.buildFinishedAt,
+    }));
+}
+function getMergedIntervalDuration(intervals) {
+    if (!intervals.length)
+        return 0;
+    const sorted = intervals
+        .map((interval) => ({
+        start: Math.min(interval.start, interval.end),
+        end: Math.max(interval.start, interval.end),
+    }))
+        .sort((a, b) => a.start - b.start);
+    let total = 0;
+    let currentStart = sorted[0].start;
+    let currentEnd = sorted[0].end;
+    for (let i = 1; i < sorted.length; i++) {
+        const interval = sorted[i];
+        if (interval.start <= currentEnd) {
+            currentEnd = Math.max(currentEnd, interval.end);
+            continue;
+        }
+        total += currentEnd - currentStart;
+        currentStart = interval.start;
+        currentEnd = interval.end;
+    }
+    total += currentEnd - currentStart;
+    return total;
 }
 function summarizeFuzzExecutions(results) {
     return {

--- a/bin/index.js
+++ b/bin/index.js
@@ -15,6 +15,7 @@ import { spawnSync } from "child_process";
 import { glob } from "glob";
 import { createInterface } from "readline";
 import { existsSync } from "fs";
+import { BuildWorkerPool } from "./build-worker-pool.js";
 const _args = process.argv.slice(2);
 const flags = [];
 const args = [];
@@ -61,6 +62,7 @@ else if (COMMANDS.includes(args[0])) {
                 resolveCommandArgs,
                 resolveListFlags,
                 resolveFeatureToggles,
+                resolveParallelJobs,
                 resolveBrowserOverride,
                 resolveExecutionModes,
                 listExecutionPlan,
@@ -75,6 +77,7 @@ else if (COMMANDS.includes(args[0])) {
                 resolveCommandArgs,
                 resolveListFlags,
                 resolveFeatureToggles,
+                resolveParallelJobs,
                 resolveBrowserOverride,
                 resolveFuzzOverrides,
                 resolveExecutionModes,
@@ -89,6 +92,7 @@ else if (COMMANDS.includes(args[0])) {
             executeFuzzCommand(_args, configPath, selectedModes, {
                 resolveCommandArgs,
                 resolveListFlags,
+                resolveJobs,
                 resolveExecutionModes,
                 listExecutionPlan,
                 runFuzzModes,
@@ -188,6 +192,18 @@ function info() {
         chalk.bold.blue("--browser <name|path>") +
         "        " +
         "Use chrome, chromium, firefox, webkit, or an executable path for web modes");
+    console.log("   " +
+        chalk.bold.blue("--jobs <n>") +
+        "                     " +
+        "Run files through an ordered worker pool");
+    console.log("   " +
+        chalk.bold.blue("--build-jobs <n>") +
+        "               " +
+        "Limit concurrent build tasks (defaults to --jobs)");
+    console.log("   " +
+        chalk.bold.blue("--run-jobs <n>") +
+        "                 " +
+        "Limit concurrent run tasks (defaults to --jobs)");
     console.log("   " +
         chalk.bold.blue("--config <path>") +
         "               " +
@@ -289,6 +305,9 @@ function printCommandHelp(command) {
         process.stdout.write("  --config <path>          Use a specific config file\n");
         process.stdout.write("  --mode <name[,name...]>  Run one or multiple named config modes\n");
         process.stdout.write("  --browser <name|path>    Use chrome, chromium, firefox, webkit, or an executable path for web modes\n");
+        process.stdout.write("  --jobs <n>               Run files through an ordered worker pool\n");
+        process.stdout.write("  --build-jobs <n>         Limit concurrent build tasks (defaults to --jobs)\n");
+        process.stdout.write("  --run-jobs <n>           Limit concurrent run tasks (defaults to --jobs)\n");
         process.stdout.write("  --create-snapshots       Create missing snapshot entries\n");
         process.stdout.write("  --overwrite-snapshots    Overwrite existing snapshot entries on mismatch\n");
         process.stdout.write("  --no-snapshot            Disable snapshot assertions for this run\n");
@@ -311,6 +330,9 @@ function printCommandHelp(command) {
         process.stdout.write("  --config <path>          Use a specific config file\n");
         process.stdout.write("  --mode <name[,name...]>  Run one or multiple named config modes\n");
         process.stdout.write("  --browser <name|path>    Use chrome, chromium, firefox, webkit, or an executable path for web modes\n");
+        process.stdout.write("  --jobs <n>               Run files through an ordered worker pool\n");
+        process.stdout.write("  --build-jobs <n>         Limit concurrent build tasks (defaults to --jobs)\n");
+        process.stdout.write("  --run-jobs <n>           Limit concurrent run tasks (defaults to --jobs)\n");
         process.stdout.write("  --create-snapshots       Create missing snapshot entries\n");
         process.stdout.write("  --overwrite-snapshots    Overwrite existing snapshot entries on mismatch\n");
         process.stdout.write("  --no-snapshot            Disable snapshot assertions for this run\n");
@@ -320,6 +342,9 @@ function printCommandHelp(command) {
         process.stdout.write("  --fuzz                   Run fuzz targets after the normal test pass\n");
         process.stdout.write("  --fuzz-runs <n>          Override fuzz iteration count for this run\n");
         process.stdout.write("  --fuzz-seed <n>          Override fuzz seed for this run\n");
+        process.stdout.write("  --jobs <n>               Run files through an ordered worker pool\n");
+        process.stdout.write("  --build-jobs <n>         Limit concurrent build tasks (defaults to --jobs)\n");
+        process.stdout.write("  --run-jobs <n>           Limit concurrent run tasks (defaults to --jobs)\n");
         process.stdout.write("  --reporter <name|path>   Use built-in reporter (default|tap) or custom module path\n");
         process.stdout.write("  --tap                    Shortcut for --reporter tap\n");
         process.stdout.write("  --verbose                Keep expanded suite/test lines and live updates\n");
@@ -337,6 +362,9 @@ function printCommandHelp(command) {
         process.stdout.write("  --mode <name[,name...]>  Run one or multiple named config modes\n");
         process.stdout.write("  --runs <n>               Override fuzz iteration count\n");
         process.stdout.write("  --seed <n>               Override fuzz seed\n");
+        process.stdout.write("  --jobs <n>               Run files through an ordered worker pool\n");
+        process.stdout.write("  --build-jobs <n>         Limit concurrent build tasks (defaults to --jobs)\n");
+        process.stdout.write("  --run-jobs <n>           Limit concurrent run tasks (defaults to --jobs)\n");
         process.stdout.write("  --list                   Preview resolved fuzz files without running\n");
         process.stdout.write("  --list-modes             Preview configured and selected mode names\n");
         process.stdout.write("  --help, -h               Show this help\n");
@@ -432,6 +460,9 @@ function resolveCommandArgs(rawArgs, command) {
         }
         if (arg == "--runs" ||
             arg == "--seed" ||
+            arg == "--jobs" ||
+            arg == "--build-jobs" ||
+            arg == "--run-jobs" ||
             arg == "--browser" ||
             arg == "--fuzz-runs" ||
             arg == "--fuzz-seed") {
@@ -440,6 +471,9 @@ function resolveCommandArgs(rawArgs, command) {
         }
         if (arg.startsWith("--runs=") ||
             arg.startsWith("--seed=") ||
+            arg.startsWith("--jobs=") ||
+            arg.startsWith("--build-jobs=") ||
+            arg.startsWith("--run-jobs=") ||
             arg.startsWith("--browser=") ||
             arg.startsWith("--fuzz-runs=") ||
             arg.startsWith("--fuzz-seed=")) {
@@ -602,6 +636,220 @@ function resolveBrowserOverride(rawArgs, command) {
     }
     return undefined;
 }
+function resolveJobs(rawArgs, command) {
+    let seenCommand = false;
+    for (let i = 0; i < rawArgs.length; i++) {
+        const arg = rawArgs[i];
+        if (!seenCommand) {
+            if (arg == command)
+                seenCommand = true;
+            continue;
+        }
+        const parsed = parseNumberFlag(rawArgs, i, "--jobs");
+        if (!parsed)
+            continue;
+        if (parsed.number < 1) {
+            throw new Error("--jobs requires a positive integer");
+        }
+        return parsed.number;
+    }
+    return 1;
+}
+function resolveParallelJobs(rawArgs, command) {
+    const baseJobs = resolveJobs(rawArgs, command);
+    let buildJobs = baseJobs;
+    let runJobs = baseJobs;
+    let seenCommand = false;
+    for (let i = 0; i < rawArgs.length; i++) {
+        const arg = rawArgs[i];
+        if (!seenCommand) {
+            if (arg == command)
+                seenCommand = true;
+            continue;
+        }
+        const buildParsed = parseNumberFlag(rawArgs, i, "--build-jobs");
+        if (buildParsed) {
+            if (buildParsed.number < 1) {
+                throw new Error("--build-jobs requires a positive integer");
+            }
+            buildJobs = buildParsed.number;
+            continue;
+        }
+        const runParsed = parseNumberFlag(rawArgs, i, "--run-jobs");
+        if (runParsed) {
+            if (runParsed.number < 1) {
+                throw new Error("--run-jobs requires a positive integer");
+            }
+            runJobs = runParsed.number;
+            continue;
+        }
+    }
+    const jobs = Math.max(baseJobs, buildJobs, runJobs);
+    return { jobs, buildJobs, runJobs };
+}
+function resolveFuzzParallelJobs(rawArgs) {
+    const baseJobs = resolveJobs(rawArgs, "fuzz");
+    let buildJobs = baseJobs;
+    let runJobs = baseJobs;
+    let seenCommand = false;
+    for (let i = 0; i < rawArgs.length; i++) {
+        const arg = rawArgs[i];
+        if (!seenCommand) {
+            if (arg == "fuzz")
+                seenCommand = true;
+            continue;
+        }
+        const buildParsed = parseNumberFlag(rawArgs, i, "--build-jobs");
+        if (buildParsed) {
+            if (buildParsed.number < 1) {
+                throw new Error("--build-jobs requires a positive integer");
+            }
+            buildJobs = buildParsed.number;
+            continue;
+        }
+        const runParsed = parseNumberFlag(rawArgs, i, "--run-jobs");
+        if (runParsed) {
+            if (runParsed.number < 1) {
+                throw new Error("--run-jobs requires a positive integer");
+            }
+            runJobs = runParsed.number;
+            continue;
+        }
+    }
+    const jobs = Math.max(baseJobs, buildJobs, runJobs);
+    return { jobs, buildJobs, runJobs };
+}
+function createBufferedStream() {
+    const chunks = [];
+    return {
+        isTTY: false,
+        write(chunk) {
+            chunks.push(typeof chunk == "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+            return true;
+        },
+        read() {
+            return chunks.join("");
+        },
+    };
+}
+async function createBufferedReporter(configPath, modeName) {
+    const stream = createBufferedStream();
+    const session = await createRunReporter(configPath, undefined, modeName, {
+        stdout: stream,
+        stderr: stream,
+    });
+    return {
+        reporter: session.reporter,
+        reporterKind: session.reporterKind,
+        runtimeName: session.runtimeName,
+        output: () => stream.read(),
+    };
+}
+async function runOrderedPool(items, jobs, worker) {
+    const width = Math.max(1, jobs);
+    let nextIndex = 0;
+    let firstError = null;
+    async function runWorker() {
+        while (true) {
+            if (firstError != null)
+                return;
+            const index = nextIndex++;
+            if (index >= items.length)
+                return;
+            try {
+                await worker(items[index], index);
+            }
+            catch (error) {
+                if (firstError == null)
+                    firstError = error;
+                return;
+            }
+        }
+    }
+    await Promise.all(Array.from({ length: Math.min(width, items.length) }, () => runWorker()));
+    if (firstError != null)
+        throw firstError;
+}
+function createAsyncLimiter(limit) {
+    const width = Math.max(1, limit);
+    let active = 0;
+    const queue = [];
+    return async function withLimit(task) {
+        if (active >= width) {
+            await new Promise((resolve) => queue.push(resolve));
+        }
+        active++;
+        try {
+            return await task();
+        }
+        finally {
+            active--;
+            const next = queue.shift();
+            if (next)
+                next();
+        }
+    };
+}
+function canRewriteParallelQueue() {
+    return Boolean(process.stdout.isTTY);
+}
+class ParallelQueueDisplay {
+    constructor(showStartLines) {
+        this.showStartLines = showStartLines;
+        this.active = new Map();
+        this.renderedLines = 0;
+        this.enabled = showStartLines && canRewriteParallelQueue();
+    }
+    start(file) {
+        const token = Symbol(file);
+        if (!this.showStartLines)
+            return token;
+        const line = `${chalk.bgBlackBright.white(" .... ")} ${file}`;
+        if (!this.enabled)
+            return token;
+        this.clear();
+        this.active.set(token, line);
+        this.render();
+        return token;
+    }
+    complete(token, output) {
+        if (!this.showStartLines || !this.enabled) {
+            process.stdout.write(output);
+            return;
+        }
+        this.clear();
+        process.stdout.write(output);
+        this.active.delete(token);
+        this.render();
+    }
+    flush() {
+        if (!this.enabled)
+            return;
+        this.clear();
+    }
+    clear() {
+        if (!this.renderedLines)
+            return;
+        for (let i = 0; i < this.renderedLines; i++) {
+            process.stdout.write("\r\x1b[2K");
+            if (i < this.renderedLines - 1)
+                process.stdout.write("\x1b[1A");
+        }
+        this.renderedLines = 0;
+    }
+    render() {
+        if (!this.enabled)
+            return;
+        const lines = Array.from(this.active.values());
+        if (!lines.length)
+            return;
+        process.stdout.write(lines.join("\n"));
+        this.renderedLines = lines.length;
+    }
+}
+function renderQueuedFileStart(display, file) {
+    return display.start(file);
+}
 function parseIntegerFlag(flag, value) {
     const parsed = Number(value);
     if (!Number.isFinite(parsed) || parsed < 0) {
@@ -704,8 +952,23 @@ async function runBuildModes(configPath, selectors, modes, buildFeatureToggles) 
 }
 async function runRuntimeModes(runFlags, configPath, selectors, modes) {
     await ensureWebBrowsersReady(configPath, modes, runFlags.browser);
-    const modeSummaryTotal = resolveConfiguredModeTotal(configPath);
+    const modeSummaryTotal = Math.max(modes.length, 1);
     const fileSummaryTotal = await resolveConfiguredFileTotal(configPath);
+    if (runFlags.jobs > 1) {
+        if (modes.length > 1) {
+            const failed = await runRuntimeMatrixParallel(runFlags, configPath, selectors, modes, modeSummaryTotal, fileSummaryTotal);
+            process.exit(failed ? 1 : 0);
+            return;
+        }
+        let failed = false;
+        for (const modeName of modes) {
+            const result = await runRuntimeSingleParallel(runFlags, configPath, selectors, modeName, modeSummaryTotal, fileSummaryTotal);
+            if (result)
+                failed = true;
+        }
+        process.exit(failed ? 1 : 0);
+        return;
+    }
     if (modes.length > 1) {
         const failed = await runRuntimeMatrix(runFlags, configPath, selectors, modes, modeSummaryTotal, fileSummaryTotal);
         process.exit(failed ? 1 : 0);
@@ -821,8 +1084,23 @@ async function runRuntimeMatrix(runFlags, configPath, selectors, modes, modeSumm
 }
 async function runTestModes(runFlags, configPath, selectors, modes, buildFeatureToggles, fuzzEnabled, fuzzOverrides) {
     await ensureWebBrowsersReady(configPath, modes, runFlags.browser);
-    const modeSummaryTotal = resolveConfiguredModeTotal(configPath);
+    const modeSummaryTotal = Math.max(modes.length, 1);
     const fileSummaryTotal = await resolveConfiguredFileTotal(configPath, selectors);
+    if (runFlags.jobs > 1) {
+        if (modes.length > 1) {
+            const failed = await runTestMatrixParallel(runFlags, configPath, selectors, modes, buildFeatureToggles, modeSummaryTotal, fileSummaryTotal, fuzzEnabled, fuzzOverrides);
+            process.exit(failed ? 1 : 0);
+            return;
+        }
+        let failed = false;
+        for (const modeName of modes) {
+            const modeFailed = await runTestSingleParallel(runFlags, configPath, selectors, buildFeatureToggles, modeSummaryTotal, fileSummaryTotal, fuzzEnabled, fuzzOverrides, modeName);
+            if (modeFailed)
+                failed = true;
+        }
+        process.exit(failed ? 1 : 0);
+        return;
+    }
     if (modes.length > 1) {
         const failed = await runTestMatrix(runFlags, configPath, selectors, modes, buildFeatureToggles, modeSummaryTotal, fileSummaryTotal, fuzzEnabled, fuzzOverrides);
         process.exit(failed ? 1 : 0);
@@ -972,11 +1250,383 @@ async function runTestMatrix(runFlags, configPath, selectors, modes, buildFeatur
 }
 async function runFuzzModes(configPath, selectors, modes, rawArgs) {
     const overrides = resolveFuzzOverrides(rawArgs, "fuzz");
+    const { jobs, buildJobs, runJobs } = resolveFuzzParallelJobs(rawArgs);
+    const clean = rawArgs.includes("--clean");
+    if (jobs > 1) {
+        const results = await runFuzzMatrixResultsParallel(configPath, selectors, modes, overrides, jobs, buildJobs, runJobs, clean);
+        const reporterSession = await createRunReporter(configPath);
+        reporterSession.reporter.onFuzzComplete?.(buildFuzzCompleteEvent(results, modes));
+        reporterSession.reporter.flush?.();
+        process.exit(results.some(hasFuzzFailures) ? 1 : 0);
+        return;
+    }
     const reporterSession = await createRunReporter(configPath);
     const results = await runFuzzMatrixResults(configPath, selectors, modes, overrides, reporterSession.reporter);
     reporterSession.reporter.onFuzzComplete?.(buildFuzzCompleteEvent(results, modes));
     reporterSession.reporter.flush?.();
     process.exit(results.some(hasFuzzFailures) ? 1 : 0);
+}
+async function runRuntimeSingleParallel(runFlags, configPath, selectors, modeName, modeSummaryTotal, fileSummaryTotal) {
+    const files = await resolveSelectedFiles(configPath, selectors);
+    if (!files.length) {
+        throw await buildNoTestFilesMatchedError(configPath, selectors);
+    }
+    const reporterSession = await createRunReporter(configPath, undefined, modeName);
+    const reporter = reporterSession.reporter;
+    const snapshotEnabled = runFlags.snapshot !== false;
+    reporter.onRunStart?.({
+        runtimeName: reporterSession.runtimeName,
+        clean: runFlags.clean,
+        verbose: runFlags.verbose,
+        snapshotEnabled,
+        createSnapshots: runFlags.createSnapshots,
+    });
+    const buildCommandsByFile = await previewBuildCommands(configPath, selectors, modeName, {});
+    const results = new Array(files.length);
+    const queueDisplay = new ParallelQueueDisplay(!runFlags.clean);
+    const runLimit = createAsyncLimiter(runFlags.runJobs);
+    const poolWidth = Math.max(runFlags.buildJobs, runFlags.runJobs);
+    await runOrderedPool(files, poolWidth, async (file, index) => {
+        const token = renderQueuedFileStart(queueDisplay, path.basename(file));
+        const buffered = await createBufferedReporter(configPath, modeName);
+        const result = await runLimit(() => run({ ...runFlags, clean: true }, configPath, [file], false, {
+            reporter: buffered.reporter,
+            reporterKind: buffered.reporterKind,
+            modeName,
+            emitRunComplete: false,
+            fileSummaryTotal: 1,
+            modeSummaryTotal,
+            modeSummaryExecuted: 1,
+            buildCommandsByFile: { [file]: buildCommandsByFile[file] ?? "" },
+        }));
+        buffered.reporter.flush?.();
+        results[index] = result;
+        queueDisplay.complete(token, buffered.output());
+    });
+    queueDisplay.flush();
+    const summary = aggregateRunResults(results);
+    summary.stats = applyConfiguredFileTotalToStats(summary.stats, fileSummaryTotal);
+    reporter.onRunComplete?.({
+        clean: runFlags.clean,
+        snapshotEnabled,
+        showCoverage: runFlags.showCoverage,
+        snapshotSummary: summary.snapshotSummary,
+        coverageSummary: summary.coverageSummary,
+        stats: summary.stats,
+        reports: summary.reports,
+        modeSummary: buildSingleModeSummary(summary.stats, summary.snapshotSummary, modeSummaryTotal),
+    });
+    reporter.flush?.();
+    return results.some((result) => result.failed);
+}
+async function runRuntimeMatrixParallel(runFlags, configPath, selectors, modes, modeSummaryTotal, fileSummaryTotal) {
+    const files = await resolveSelectedFiles(configPath, selectors);
+    if (!files.length) {
+        throw await buildNoTestFilesMatchedError(configPath, selectors);
+    }
+    const reporterSession = await createRunReporter(configPath);
+    const reporter = reporterSession.reporter;
+    const snapshotEnabled = runFlags.snapshot !== false;
+    reporter.onRunStart?.({
+        runtimeName: reporterSession.runtimeName,
+        clean: runFlags.clean,
+        verbose: runFlags.verbose,
+        snapshotEnabled,
+        createSnapshots: runFlags.createSnapshots,
+    });
+    const silentReporter = {};
+    const modeLabels = modes.map((modeName) => modeName ?? "default");
+    const showPerModeTimes = Boolean(runFlags.verbose);
+    const duplicateSpecBasenames = resolveDuplicateSpecBasenames(files);
+    const ordered = new Array(files.length);
+    const queueDisplay = new ParallelQueueDisplay(!runFlags.clean);
+    const poolWidth = Math.max(runFlags.jobs, runFlags.buildJobs, runFlags.runJobs);
+    const buildPool = new BuildWorkerPool(runFlags.buildJobs);
+    try {
+        await runOrderedPool(files, poolWidth, async (file, fileIndex) => {
+            const fileName = path.basename(file);
+            const token = renderQueuedFileStart(queueDisplay, fileName);
+            const fileResults = [];
+            const modeTimes = modes.map(() => "...");
+            for (let i = 0; i < modes.length; i++) {
+                const modeName = modes[i];
+                await buildPool.buildFileMode({
+                    configPath,
+                    file,
+                    modeName,
+                });
+                const buildInvocation = await getBuildInvocationPreview(configPath, file, modeName, {});
+                const artifactKey = resolvePerFileArtifactKey(file, duplicateSpecBasenames);
+                const result = await run(runFlags, configPath, [file], false, {
+                    reporter: silentReporter,
+                    reporterKind: "default",
+                    emitRunStart: false,
+                    emitRunComplete: false,
+                    logFileName: `run.${artifactKey}.log.json`,
+                    coverageFileName: `coverage.${artifactKey}.log.json`,
+                    buildCommand: formatBuildInvocation(buildInvocation),
+                    modeName,
+                });
+                modeTimes[i] = formatMatrixModeTime(result.stats.time);
+                fileResults.push(result);
+            }
+            ordered[fileIndex] = { fileName, fileResults, modeTimes };
+            queueDisplay.complete(token, formatMatrixFileResultLine(fileName, modeLabels, fileResults, modeTimes, showPerModeTimes) + "\n");
+        });
+    }
+    finally {
+        await buildPool.close();
+    }
+    queueDisplay.flush();
+    const allResults = [];
+    const modeState = modes.map(() => ({ failed: false, passed: false }));
+    const fileState = files.map(() => ({ failed: false, passed: false }));
+    for (let fileIndex = 0; fileIndex < ordered.length; fileIndex++) {
+        const fileResults = ordered[fileIndex].fileResults;
+        for (let i = 0; i < fileResults.length; i++) {
+            const result = fileResults[i];
+            allResults.push(result);
+            if (result.failed)
+                modeState[i].failed = true;
+            else if (result.stats.passedFiles > 0)
+                modeState[i].passed = true;
+        }
+        const verdict = resolveMatrixVerdict(fileResults);
+        if (verdict == "fail")
+            fileState[fileIndex].failed = true;
+        else if (verdict == "ok")
+            fileState[fileIndex].passed = true;
+    }
+    const summary = aggregateRunResults(allResults);
+    summary.stats = applyMatrixFileSummaryToStats(summary.stats, fileState, fileSummaryTotal);
+    reporter.onRunComplete?.({
+        clean: runFlags.clean,
+        snapshotEnabled,
+        showCoverage: runFlags.showCoverage,
+        snapshotSummary: summary.snapshotSummary,
+        coverageSummary: summary.coverageSummary,
+        stats: summary.stats,
+        reports: summary.reports,
+        modeSummary: buildModeSummary(modeState, modeSummaryTotal),
+    });
+    reporter.flush?.();
+    return allResults.some((result) => result.failed);
+}
+async function runTestSingleParallel(runFlags, configPath, selectors, buildFeatureToggles, modeSummaryTotal, fileSummaryTotal, fuzzEnabled, fuzzOverrides, modeName) {
+    const files = await resolveSelectedFiles(configPath, selectors);
+    if (!files.length && !fuzzEnabled) {
+        throw await buildNoTestFilesMatchedError(configPath, selectors);
+    }
+    const reporterSession = await createRunReporter(configPath, undefined, modeName);
+    const reporter = reporterSession.reporter;
+    const snapshotEnabled = runFlags.snapshot !== false;
+    reporter.onRunStart?.({
+        runtimeName: reporterSession.runtimeName,
+        clean: runFlags.clean,
+        verbose: runFlags.verbose,
+        snapshotEnabled,
+        createSnapshots: runFlags.createSnapshots,
+    });
+    const duplicateSpecBasenames = resolveDuplicateSpecBasenames(files);
+    const results = new Array(files.length);
+    const queueDisplay = new ParallelQueueDisplay(!runFlags.clean);
+    const poolWidth = Math.max(runFlags.jobs, runFlags.buildJobs, runFlags.runJobs);
+    if (files.length) {
+        const buildPool = new BuildWorkerPool(runFlags.buildJobs);
+        try {
+            await runOrderedPool(files, poolWidth, async (file, index) => {
+                const token = renderQueuedFileStart(queueDisplay, path.basename(file));
+                await buildPool.buildFileMode({
+                    configPath,
+                    file,
+                    modeName,
+                    featureToggles: buildFeatureToggles,
+                });
+                const buildInvocation = await getBuildInvocationPreview(configPath, file, modeName, buildFeatureToggles);
+                const artifactKey = resolvePerFileArtifactKey(file, duplicateSpecBasenames);
+                const buffered = await createBufferedReporter(configPath, modeName);
+                const result = await run({ ...runFlags, clean: true }, configPath, [file], false, {
+                    reporter: buffered.reporter,
+                    reporterKind: buffered.reporterKind,
+                    emitRunComplete: false,
+                    logFileName: `test.${artifactKey}.log.json`,
+                    coverageFileName: `coverage.${artifactKey}.log.json`,
+                    buildCommand: formatBuildInvocation(buildInvocation),
+                    modeName,
+                });
+                buffered.reporter.flush?.();
+                results[index] = result;
+                queueDisplay.complete(token, buffered.output());
+            });
+        }
+        finally {
+            await buildPool.close();
+        }
+    }
+    queueDisplay.flush();
+    const runResults = results.filter(Boolean);
+    const summary = aggregateRunResults(runResults);
+    summary.stats = applyConfiguredFileTotalToStats(summary.stats, fileSummaryTotal);
+    let failed = runResults.some((result) => result.failed);
+    let fuzzSummary;
+    if (fuzzEnabled) {
+        if (reporterSession.reporterKind == "default") {
+            process.stdout.write("\n");
+        }
+        const fuzzResults = await runFuzzMatrixResultsParallel(configPath, selectors, [modeName], fuzzOverrides, runFlags.jobs, runFlags.buildJobs, runFlags.runJobs, runFlags.clean);
+        if (fuzzResults.some(hasFuzzFailures))
+            failed = true;
+        fuzzSummary = summarizeFuzzExecutions(fuzzResults);
+    }
+    reporter.onRunComplete?.({
+        clean: runFlags.clean,
+        snapshotEnabled,
+        showCoverage: runFlags.showCoverage,
+        snapshotSummary: summary.snapshotSummary,
+        coverageSummary: summary.coverageSummary,
+        stats: summary.stats,
+        reports: summary.reports,
+        fuzzSummary,
+        modeSummary: buildSingleModeSummary(summary.stats, summary.snapshotSummary, modeSummaryTotal),
+    });
+    reporter.flush?.();
+    return failed;
+}
+async function runTestMatrixParallel(runFlags, configPath, selectors, modes, buildFeatureToggles, modeSummaryTotal, fileSummaryTotal, fuzzEnabled, fuzzOverrides) {
+    const files = await resolveSelectedFiles(configPath, selectors);
+    if (!files.length) {
+        if (!fuzzEnabled) {
+            throw await buildNoTestFilesMatchedError(configPath, selectors);
+        }
+        const fuzzFiles = await resolveSelectedFuzzFiles(configPath, selectors);
+        if (!fuzzFiles.length) {
+            throw await buildNoTestFilesMatchedError(configPath, selectors, true);
+        }
+    }
+    const reporterSession = await createRunReporter(configPath);
+    const reporter = reporterSession.reporter;
+    const snapshotEnabled = runFlags.snapshot !== false;
+    reporter.onRunStart?.({
+        runtimeName: reporterSession.runtimeName,
+        clean: runFlags.clean,
+        verbose: runFlags.verbose,
+        snapshotEnabled,
+        createSnapshots: runFlags.createSnapshots,
+    });
+    const silentReporter = {};
+    const modeLabels = modes.map((modeName) => modeName ?? "default");
+    const showPerModeTimes = Boolean(runFlags.verbose);
+    const duplicateSpecBasenames = resolveDuplicateSpecBasenames(files);
+    const ordered = new Array(files.length);
+    const queueDisplay = new ParallelQueueDisplay(!runFlags.clean);
+    const poolWidth = Math.max(runFlags.jobs, runFlags.buildJobs, runFlags.runJobs);
+    const buildPool = new BuildWorkerPool(runFlags.buildJobs);
+    try {
+        await runOrderedPool(files, poolWidth, async (file, fileIndex) => {
+            const fileName = path.basename(file);
+            const token = renderQueuedFileStart(queueDisplay, fileName);
+            const fileResults = [];
+            const modeTimes = modes.map(() => "...");
+            for (let i = 0; i < modes.length; i++) {
+                const modeName = modes[i];
+                await buildPool.buildFileMode({
+                    configPath,
+                    file,
+                    modeName,
+                    featureToggles: buildFeatureToggles,
+                });
+                const buildInvocation = await getBuildInvocationPreview(configPath, file, modeName, buildFeatureToggles);
+                const artifactKey = resolvePerFileArtifactKey(file, duplicateSpecBasenames);
+                const result = await run(runFlags, configPath, [file], false, {
+                    reporter: silentReporter,
+                    reporterKind: "default",
+                    emitRunStart: false,
+                    emitRunComplete: false,
+                    logFileName: `test.${artifactKey}.log.json`,
+                    coverageFileName: `coverage.${artifactKey}.log.json`,
+                    buildCommand: formatBuildInvocation(buildInvocation),
+                    modeName,
+                });
+                modeTimes[i] = formatMatrixModeTime(result.stats.time);
+                fileResults.push(result);
+            }
+            ordered[fileIndex] = { fileName, fileResults, modeTimes };
+            queueDisplay.complete(token, formatMatrixFileResultLine(fileName, modeLabels, fileResults, modeTimes, showPerModeTimes) + "\n");
+        });
+    }
+    finally {
+        await buildPool.close();
+    }
+    queueDisplay.flush();
+    const allResults = [];
+    const modeState = modes.map(() => ({ failed: false, passed: false }));
+    const fileState = files.map(() => ({ failed: false, passed: false }));
+    for (let fileIndex = 0; fileIndex < ordered.length; fileIndex++) {
+        const entry = ordered[fileIndex];
+        for (let i = 0; i < entry.fileResults.length; i++) {
+            const result = entry.fileResults[i];
+            allResults.push(result);
+            if (result.failed)
+                modeState[i].failed = true;
+            else if (result.stats.passedFiles > 0)
+                modeState[i].passed = true;
+        }
+        const verdict = resolveMatrixVerdict(entry.fileResults);
+        if (verdict == "fail")
+            fileState[fileIndex].failed = true;
+        else if (verdict == "ok")
+            fileState[fileIndex].passed = true;
+    }
+    const summary = aggregateRunResults(allResults);
+    summary.stats = applyMatrixFileSummaryToStats(summary.stats, fileState, fileSummaryTotal);
+    let failed = allResults.some((result) => result.failed);
+    let fuzzSummary;
+    if (fuzzEnabled) {
+        if (reporterSession.reporterKind == "default") {
+            process.stdout.write("\n");
+        }
+        const fuzzResults = await runFuzzMatrixResultsParallel(configPath, selectors, modes, fuzzOverrides, runFlags.jobs, runFlags.buildJobs, runFlags.runJobs, runFlags.clean);
+        if (fuzzResults.some(hasFuzzFailures))
+            failed = true;
+        fuzzSummary = summarizeFuzzExecutions(fuzzResults);
+    }
+    reporter.onRunComplete?.({
+        clean: runFlags.clean,
+        snapshotEnabled,
+        showCoverage: runFlags.showCoverage,
+        snapshotSummary: summary.snapshotSummary,
+        coverageSummary: summary.coverageSummary,
+        stats: summary.stats,
+        reports: summary.reports,
+        fuzzSummary,
+        modeSummary: buildModeSummary(modeState, modeSummaryTotal),
+    });
+    reporter.flush?.();
+    return failed;
+}
+async function runFuzzMatrixResultsParallel(configPath, selectors, modes, overrides, jobs, buildJobs, runJobs, clean) {
+    const files = await resolveSelectedFuzzFiles(configPath, selectors);
+    if (!files.length) {
+        throw new Error(`No fuzz files matched: ${selectors.length ? selectors.join(", ") : "configured input patterns"}`);
+    }
+    const ordered = new Array(files.length);
+    const queueDisplay = new ParallelQueueDisplay(!clean);
+    const poolWidth = Math.max(jobs, buildJobs, runJobs);
+    await runOrderedPool(files, poolWidth, async (file, index) => {
+        const token = renderQueuedFileStart(queueDisplay, path.basename(file));
+        const fileResults = [];
+        for (const modeName of modes) {
+            const modeResults = await fuzz(configPath, [file], modeName, overrides);
+            fileResults.push(...modeResults);
+        }
+        ordered[index] = fileResults;
+        const buffered = await createBufferedReporter(configPath);
+        buffered.reporter.onFuzzFileComplete?.({ file, results: fileResults });
+        buffered.reporter.flush?.();
+        queueDisplay.complete(token, buffered.output());
+    });
+    queueDisplay.flush();
+    return ordered.flat();
 }
 async function runFuzzMatrixResults(configPath, selectors, modes, overrides, reporter) {
     const files = await resolveSelectedFuzzFiles(configPath, selectors);
@@ -1059,6 +1709,12 @@ function isSkippedFuzzResult(result) {
         result.fuzzers.every((fuzzer) => fuzzer.skipped > 0));
 }
 function renderMatrixFileResult(file, modes, results, modeTimes, liveMatrix, showPerModeTimes) {
+    const line = formatMatrixFileResultLine(file, modes, results, modeTimes, showPerModeTimes);
+    if (liveMatrix)
+        clearLiveLine();
+    process.stdout.write(line + "\n");
+}
+function formatMatrixFileResultLine(file, modes, results, modeTimes, showPerModeTimes) {
     const verdict = resolveMatrixVerdict(results);
     const badge = verdict == "fail"
         ? chalk.bgRed.white(" FAIL ")
@@ -1075,10 +1731,7 @@ function renderMatrixFileResult(file, modes, results, modeTimes, liveMatrix, sho
         : failedModes.length
             ? ` ${chalk.dim(`(failed: ${failedModes.join(", ")})`)}`
             : "";
-    const line = `${badge} ${file} ${chalk.dim(timingText)}${suffix}`;
-    if (liveMatrix)
-        clearLiveLine();
-    process.stdout.write(line + "\n");
+    return `${badge} ${file} ${chalk.dim(timingText)}${suffix}`;
 }
 function resolveMatrixVerdict(results) {
     if (results.some((result) => result.failed))

--- a/bin/reporters/default.js
+++ b/bin/reporters/default.js
@@ -545,7 +545,10 @@ function renderTotals(stats, event) {
     if (event.modeSummary) {
         renderModeSummary(event.modeSummary, layout);
     }
-    process.stdout.write(chalk.bold("Time:".padEnd(9)) + formatTime(stats.time) + "\n");
+    process.stdout.write(chalk.bold("Time:".padEnd(9)) +
+        formatTime(stats.time) +
+        chalk.dim(` (${formatTime(event.buildTime)} build)`) +
+        "\n");
 }
 function renderModeSummary(summary, layout) {
     renderSummaryLine("Modes:", summary, layout);
@@ -563,7 +566,10 @@ function renderStandaloneFuzzTotals(event) {
     renderSummaryLine("Fuzz:", event.fuzzingSummary, layout);
     renderSummaryLine("Suites:", event.suiteSummary, layout);
     renderSummaryLine("Modes:", event.modeSummary, layout);
-    process.stdout.write(chalk.bold("Time:".padEnd(9)) + formatTime(event.time) + "\n");
+    process.stdout.write(chalk.bold("Time:".padEnd(9)) +
+        formatTime(event.time) +
+        chalk.dim(` (${formatTime(event.buildTime)} build)`) +
+        "\n");
 }
 function createSummaryLayout(summaries) {
     return {

--- a/bin/reporters/default.js
+++ b/bin/reporters/default.js
@@ -265,7 +265,7 @@ class DefaultReporter {
             renderFailedSuites(event.stats.failedEntries);
         }
         if (event.snapshotEnabled) {
-            renderSnapshotSummary(event.snapshotSummary, !this.hasRenderedFuzzFiles);
+            renderSnapshotSummary(event.snapshotSummary, this.hasRenderedTestFiles || this.hasRenderedFuzzFiles);
         }
         if (event.coverageSummary.enabled) {
             renderCoverageSummary(event.coverageSummary);
@@ -555,15 +555,17 @@ function createSummaryLayout(summaries) {
     return {
         failedWidth: Math.max(...summaries.map((summary) => summary ? `${summary.failed} failed`.length : 0)),
         skippedWidth: Math.max(...summaries.map((summary) => summary ? `${summary.skipped} skipped`.length : 0)),
+        totalWidth: Math.max(...summaries.map((summary) => summary ? `${summary.total} total`.length : 0)),
     };
 }
 function renderSummaryLine(label, summary, layout = {
     failedWidth: `${summary.failed} failed`.length,
     skippedWidth: `${summary.skipped} skipped`.length,
+    totalWidth: `${summary.total} total`.length,
 }) {
     const failedText = `${summary.failed} failed`;
     const skippedText = `${summary.skipped} skipped`;
-    const totalText = `${" ".repeat(Math.max(0, layout.skippedWidth - skippedText.length))}${summary.total} total`;
+    const totalText = `${summary.total} total`;
     process.stdout.write(chalk.bold(label.padEnd(9)));
     process.stdout.write(summary.failed
         ? chalk.bold.red(failedText.padStart(layout.failedWidth))
@@ -571,7 +573,7 @@ function renderSummaryLine(label, summary, layout = {
     process.stdout.write(", ");
     process.stdout.write(chalk.gray(skippedText.padStart(layout.skippedWidth)));
     process.stdout.write(", ");
-    process.stdout.write(totalText + "\n");
+    process.stdout.write(totalText.padStart(layout.totalWidth) + "\n");
 }
 function renderCoverageSummary(summary) {
     const pct = summary.total

--- a/bin/reporters/default.js
+++ b/bin/reporters/default.js
@@ -136,7 +136,17 @@ class DefaultReporter {
             this.renderVerboseState();
             return;
         }
-        if (this.verboseMode || !this.canRewriteLine()) {
+        if (!this.verboseMode) {
+            if (!this.canRewriteLine()) {
+                this.context.stdout.write(`${this.badgeRunning()} ${event.file}\n`);
+                return;
+            }
+            this.clearRenderedBlock();
+            this.context.stdout.write(`${this.badgeRunning()} ${event.file}`);
+            this.renderedLines = 1;
+            return;
+        }
+        if (!this.canRewriteLine()) {
             this.context.stdout.write(`${this.badgeRunning()} ${event.file}\n`);
             return;
         }
@@ -165,6 +175,8 @@ class DefaultReporter {
     onSuiteStart(event) {
         if (this.cleanMode)
             return;
+        if (!this.verboseMode)
+            return;
         const depth = Math.max(event.depth, 0);
         if (this.verboseMode && this.canRewriteLine()) {
             if (this.currentFile !== event.file)
@@ -189,6 +201,8 @@ class DefaultReporter {
     }
     onSuiteEnd(event) {
         if (this.cleanMode)
+            return;
+        if (!this.verboseMode)
             return;
         const depth = Math.max(event.depth, 0);
         const verdict = String(event.verdict ?? "none");
@@ -265,7 +279,7 @@ class DefaultReporter {
             renderFailedSuites(event.stats.failedEntries);
         }
         if (event.snapshotEnabled) {
-            renderSnapshotSummary(event.snapshotSummary, this.hasRenderedTestFiles || this.hasRenderedFuzzFiles);
+            renderSnapshotSummary(event.snapshotSummary, true);
         }
         if (event.coverageSummary.enabled) {
             renderCoverageSummary(event.coverageSummary);

--- a/bin/reporters/tap.js
+++ b/bin/reporters/tap.js
@@ -24,6 +24,7 @@ class TapReporter {
         this.pendingFuzzPoints.push(...collectFuzzTapPoints({
             results: event.results,
             time: event.results.reduce((sum, item) => sum + item.time, 0),
+            buildTime: event.results.reduce((sum, item) => sum + item.buildTime, 0),
             fuzzingSummary: { failed: 0, skipped: 0, total: 0 },
             suiteSummary: { failed: 0, skipped: 0, total: 0 },
             modeSummary: { failed: 0, skipped: 0, total: 0 },

--- a/cli/build-worker-pool.ts
+++ b/cli/build-worker-pool.ts
@@ -1,6 +1,6 @@
 import { ChildProcess, spawn } from "child_process";
 import { fileURLToPath } from "url";
-import {
+import type {
   BuildConfigOverrides,
   BuildFeatureToggles,
 } from "./commands/build-core.js";

--- a/cli/build-worker-pool.ts
+++ b/cli/build-worker-pool.ts
@@ -1,0 +1,218 @@
+import { ChildProcess, spawn } from "child_process";
+import { fileURLToPath } from "url";
+import {
+  BuildConfigOverrides,
+  BuildFeatureToggles,
+} from "./commands/build-core.js";
+
+type BuildTask = {
+  id: number;
+  configPath?: string;
+  file: string;
+  modeName?: string;
+  featureToggles: BuildFeatureToggles;
+  overrides: BuildConfigOverrides;
+  resolve: () => void;
+  reject: (error: Error) => void;
+};
+
+type WorkerProcess = {
+  child: ChildProcess;
+  busy: boolean;
+  task: BuildTask | null;
+};
+
+type SignaturePool = {
+  workers: WorkerProcess[];
+  queue: BuildTask[];
+};
+
+type WorkerMessage =
+  | {
+      type: "done";
+      id: number;
+    }
+  | {
+      type: "error";
+      id: number;
+      error: {
+        name?: unknown;
+        message?: unknown;
+        stack?: unknown;
+        [key: string]: unknown;
+      };
+    };
+
+export class BuildWorkerPool {
+  private readonly size: number;
+  private readonly pools = new Map<string, SignaturePool>();
+  private nextId = 1;
+  private closed = false;
+
+  constructor(size: number) {
+    this.size = Math.max(1, size);
+  }
+
+  buildFileMode(args: {
+    configPath?: string;
+    file: string;
+    modeName?: string;
+    featureToggles?: BuildFeatureToggles;
+    overrides?: BuildConfigOverrides;
+  }): Promise<void> {
+    if (this.closed) {
+      return Promise.reject(new Error("build worker pool is closed"));
+    }
+    const featureToggles = args.featureToggles ?? {};
+    const overrides = args.overrides ?? {};
+    const signature = buildSignature(args.modeName, featureToggles, overrides);
+    const pool = this.getPool(signature);
+    return new Promise<void>((resolve, reject) => {
+      pool.queue.push({
+        id: this.nextId++,
+        configPath: args.configPath,
+        file: args.file,
+        modeName: args.modeName,
+        featureToggles,
+        overrides,
+        resolve,
+        reject,
+      });
+      this.pump(pool);
+    });
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    const waits: Promise<void>[] = [];
+    for (const pool of this.pools.values()) {
+      while (pool.queue.length) {
+        const task = pool.queue.shift()!;
+        task.reject(new Error("build worker pool closed"));
+      }
+      for (const worker of pool.workers) {
+        waits.push(
+          new Promise<void>((resolve) => {
+            if (worker.child.exitCode != null || worker.child.killed) {
+              resolve();
+              return;
+            }
+            worker.child.once("exit", () => resolve());
+            worker.child.kill();
+          }),
+        );
+      }
+    }
+    await Promise.all(waits);
+  }
+
+  private getPool(signature: string): SignaturePool {
+    let pool = this.pools.get(signature);
+    if (pool) return pool;
+    pool = {
+      workers: Array.from({ length: this.size }, () =>
+        this.spawnWorker(signature),
+      ),
+      queue: [],
+    };
+    this.pools.set(signature, pool);
+    return pool;
+  }
+
+  private spawnWorker(signature: string): WorkerProcess {
+    const workerPath = fileURLToPath(
+      new URL("./build-worker.js", import.meta.url),
+    );
+    const child = spawn(process.execPath, [workerPath], {
+      stdio: ["ignore", "ignore", "ignore", "ipc"],
+    });
+    const worker: WorkerProcess = {
+      child,
+      busy: false,
+      task: null,
+    };
+    child.on("message", (message: WorkerMessage) => {
+      this.onMessage(signature, worker, message);
+    });
+    child.on("exit", () => {
+      const pool = this.pools.get(signature);
+      const failedTask = worker.task;
+      worker.busy = false;
+      worker.task = null;
+      if (failedTask) {
+        failedTask.reject(new Error("build worker exited unexpectedly"));
+      }
+      if (!pool || this.closed) return;
+      const index = pool.workers.indexOf(worker);
+      if (index >= 0) {
+        pool.workers[index] = this.spawnWorker(signature);
+      }
+      this.pump(pool);
+    });
+    return worker;
+  }
+
+  private onMessage(
+    signature: string,
+    worker: WorkerProcess,
+    message: WorkerMessage,
+  ): void {
+    const pool = this.pools.get(signature);
+    const task = worker.task;
+    if (!pool || !task || task.id !== message.id) return;
+    worker.busy = false;
+    worker.task = null;
+    if (message.type == "done") {
+      task.resolve();
+    } else {
+      task.reject(deserializeError(message.error));
+    }
+    this.pump(pool);
+  }
+
+  private pump(pool: SignaturePool): void {
+    for (const worker of pool.workers) {
+      if (worker.busy) continue;
+      const task = pool.queue.shift();
+      if (!task) return;
+      worker.busy = true;
+      worker.task = task;
+      worker.child.send({
+        type: "build-file",
+        id: task.id,
+        configPath: task.configPath,
+        file: task.file,
+        modeName: task.modeName,
+        featureToggles: task.featureToggles,
+        overrides: task.overrides,
+      });
+    }
+  }
+}
+
+function buildSignature(
+  modeName: string | undefined,
+  featureToggles: BuildFeatureToggles,
+  overrides: BuildConfigOverrides,
+): string {
+  return JSON.stringify({
+    modeName: modeName ?? "default",
+    featureToggles,
+    overrides,
+  });
+}
+
+function deserializeError(
+  payload: Extract<WorkerMessage, { type: "error" }>["error"],
+): Error {
+  const error = new Error(
+    typeof payload.message == "string" ? payload.message : "unknown error",
+  ) as Error & Record<string, unknown>;
+  error.name = typeof payload.name == "string" ? payload.name : "Error";
+  if (typeof payload.stack == "string") error.stack = payload.stack;
+  for (const [key, value] of Object.entries(payload)) {
+    if (key == "name" || key == "message" || key == "stack") continue;
+    error[key] = value;
+  }
+  return error;
+}

--- a/cli/build-worker.ts
+++ b/cli/build-worker.ts
@@ -1,0 +1,80 @@
+import {
+  build,
+  BuildConfigOverrides,
+  BuildFeatureToggles,
+} from "./commands/build-core.js";
+
+process.env.AS_TEST_BUILD_API = "1";
+
+type BuildTaskMessage = {
+  type: "build-file";
+  id: number;
+  configPath?: string;
+  file: string;
+  modeName?: string;
+  featureToggles: BuildFeatureToggles;
+  overrides: BuildConfigOverrides;
+};
+
+type BuildSuccessMessage = {
+  type: "done";
+  id: number;
+};
+
+type BuildErrorMessage = {
+  type: "error";
+  id: number;
+  error: {
+    name: string;
+    message: string;
+    stack?: string;
+    [key: string]: unknown;
+  };
+};
+
+process.on("message", async (message: BuildTaskMessage) => {
+  if (!message || message.type != "build-file") return;
+  try {
+    await build(
+      message.configPath,
+      [message.file],
+      message.modeName,
+      message.featureToggles,
+      message.overrides,
+    );
+    send({
+      type: "done",
+      id: message.id,
+    } satisfies BuildSuccessMessage);
+  } catch (error) {
+    send({
+      type: "error",
+      id: message.id,
+      error: serializeError(error),
+    } satisfies BuildErrorMessage);
+  }
+});
+
+function send(message: BuildSuccessMessage | BuildErrorMessage): void {
+  if (!process.send) return;
+  process.send(message);
+}
+
+function serializeError(error: unknown): BuildErrorMessage["error"] {
+  if (!(error instanceof Error)) {
+    return {
+      name: "Error",
+      message: typeof error == "string" ? error : "unknown error",
+    };
+  }
+  const out: BuildErrorMessage["error"] = {
+    name: error.name,
+    message: error.message,
+    stack: error.stack,
+  };
+  const errorRecord = error as unknown as Record<string, unknown>;
+  for (const key of Object.keys(error)) {
+    out[key] = errorRecord[key];
+  }
+  return out;
+}

--- a/cli/build-worker.ts
+++ b/cli/build-worker.ts
@@ -1,5 +1,5 @@
-import {
-  build,
+import { build } from "./commands/build-core.js";
+import type {
   BuildConfigOverrides,
   BuildFeatureToggles,
 } from "./commands/build-core.js";

--- a/cli/commands/build-core.ts
+++ b/cli/commands/build-core.ts
@@ -16,6 +16,7 @@ import {
   resolveProjectModule,
 } from "../util.js";
 import { persistCrashRecord } from "../crash-store.js";
+import { BuildWorkerPool } from "../build-worker-pool.js";
 
 const DEFAULT_CONFIG_PATH = path.join(process.cwd(), "./as-test.config.json");
 
@@ -111,6 +112,20 @@ export async function build(
     AS_TEST_COVERAGE_ENABLED: coverageEnabled ? "1" : "0",
   };
 
+  if (!process.env.AS_TEST_BUILD_API && !hasCustomBuildCommand(config)) {
+    const pool = getSerialBuildWorkerPool();
+    for (const file of inputFiles) {
+      await pool.buildFileMode({
+        configPath,
+        file,
+        modeName,
+        featureToggles,
+        overrides,
+      });
+    }
+    return;
+  }
+
   for (const file of inputFiles) {
     const outFile = `${config.outDir}/${resolveArtifactFileName(
       file,
@@ -160,6 +175,15 @@ export async function build(
       });
     }
   }
+}
+
+let serialBuildWorkerPool: BuildWorkerPool | null = null;
+
+function getSerialBuildWorkerPool(): BuildWorkerPool {
+  if (!serialBuildWorkerPool) {
+    serialBuildWorkerPool = new BuildWorkerPool(1);
+  }
+  return serialBuildWorkerPool;
 }
 
 export async function getBuildInvocationPreview(

--- a/cli/commands/build-core.ts
+++ b/cli/commands/build-core.ts
@@ -2,8 +2,12 @@ import { existsSync } from "fs";
 import { Config } from "../types.js";
 import { glob } from "glob";
 import chalk from "chalk";
-import { spawnSync } from "child_process";
+import { spawn } from "child_process";
 import * as path from "path";
+import {
+  createMemoryStream,
+  main as ascMain,
+} from "assemblyscript/dist/asc.js";
 import {
   applyMode,
   getPkgRunner,
@@ -29,6 +33,7 @@ export type BuildConfigOverrides = {
 type BuildInvocation = {
   command: string;
   args: string[];
+  apiArgs?: string[];
 };
 
 export type { BuildInvocation };
@@ -122,7 +127,7 @@ export async function build(
       featureToggles,
     );
     try {
-      buildFile(invocation, buildEnv);
+      await buildFile(invocation, buildEnv);
     } catch (error) {
       const modeLabel = modeName ?? "default";
       const stdout = getBuildStdout(error);
@@ -239,6 +244,7 @@ function getBuildCommand(
   return {
     command: ascInvocation.command,
     args,
+    apiArgs: args.slice(1),
   };
 }
 
@@ -414,23 +420,116 @@ function ensureDeps(config: Config): void {
   }
 }
 
-function buildFile(invocation: BuildInvocation, env: NodeJS.ProcessEnv): void {
-  const result = spawnSync(invocation.command, invocation.args, {
-    stdio: ["ignore", "pipe", "pipe"],
-    encoding: "utf8",
-    env,
-    shell: false,
+async function buildFile(
+  invocation: BuildInvocation,
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  if (process.env.AS_TEST_BUILD_API == "1" && invocation.apiArgs?.length) {
+    await buildFileViaApi(invocation.apiArgs, env);
+    return;
+  }
+  await buildFileViaSpawn(invocation, env);
+}
+
+async function buildFileViaApi(
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  const stdout = createMemoryStream((chunk) => {
+    stdoutChunks.push(
+      typeof chunk == "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+    );
   });
-  if (result.error) throw result.error;
-  if (result.status !== 0) {
-    const error = new Error(
-      result.stderr?.trim() ||
-        result.stdout?.trim() ||
-        `command exited with code ${result.status}`,
-    ) as Error & { stderr?: string; stdout?: string };
-    error.stderr = result.stderr ?? "";
-    error.stdout = result.stdout ?? "";
-    throw error;
+  const stderr = createMemoryStream((chunk) => {
+    stderrChunks.push(
+      typeof chunk == "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+    );
+  });
+  const previousEnv = snapshotEnv();
+  applyEnv(env);
+  try {
+    const result = await ascMain(args, { stdout, stderr });
+    if (result.error) {
+      const error = result.error as Error & {
+        stderr?: string;
+        stdout?: string;
+      };
+      error.stderr = stderrChunks.join("").trim();
+      error.stdout = stdoutChunks.join("").trim();
+      throw error;
+    }
+  } finally {
+    restoreEnv(previousEnv);
+  }
+}
+
+async function buildFileViaSpawn(
+  invocation: BuildInvocation,
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(invocation.command, invocation.args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env,
+      shell: false,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      const error = new Error(
+        stderr.trim() || stdout.trim() || `command exited with code ${code}`,
+      ) as Error & { stderr?: string; stdout?: string };
+      error.stderr = stderr.trim();
+      error.stdout = stdout.trim();
+      reject(error);
+    });
+  });
+}
+
+function snapshotEnv(): Record<string, string | undefined> {
+  return { ...process.env };
+}
+
+function applyEnv(nextEnv: NodeJS.ProcessEnv): void {
+  const keys = new Set([
+    ...Object.keys(process.env),
+    ...Object.keys(nextEnv as Record<string, string | undefined>),
+  ]);
+  for (const key of keys) {
+    const value = nextEnv[key];
+    if (value == undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function restoreEnv(previousEnv: Record<string, string | undefined>): void {
+  const keys = new Set([
+    ...Object.keys(process.env),
+    ...Object.keys(previousEnv),
+  ]);
+  for (const key of keys) {
+    const value = previousEnv[key];
+    if (value == undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
   }
 }
 

--- a/cli/commands/fuzz-core.ts
+++ b/cli/commands/fuzz-core.ts
@@ -41,6 +41,9 @@ export type FuzzResult = {
   crashFiles: string[];
   seed: number;
   time: number;
+  buildTime: number;
+  buildStartedAt: number;
+  buildFinishedAt: number;
   fuzzers: FuzzerRunResult[];
 };
 
@@ -71,6 +74,7 @@ export async function fuzz(
   const duplicateBasenames = resolveDuplicateBasenames(inputFiles);
   const results: FuzzResult[] = [];
   for (const file of inputFiles) {
+    const buildStartedAt = Date.now();
     await build(
       configPath,
       [file],
@@ -78,12 +82,17 @@ export async function fuzz(
       { coverage: false },
       { target: "bindings", args: ["--use", "AS_TEST_FUZZ=1"], kind: "fuzz" },
     );
+    const buildFinishedAt = Date.now();
+    const buildTime = buildFinishedAt - buildStartedAt;
     results.push(
       await runFuzzTarget(
         file,
         mode.config.outDir,
         duplicateBasenames,
         config,
+        buildStartedAt,
+        buildFinishedAt,
+        buildTime,
         modeName,
       ),
     );
@@ -109,6 +118,9 @@ async function runFuzzTarget(
   outDir: string,
   duplicateBasenames: Set<string>,
   config: FuzzConfig,
+  buildStartedAt: number,
+  buildFinishedAt: number,
+  buildTime: number,
   modeName?: string,
 ): Promise<FuzzResult> {
   const startedAt = Date.now();
@@ -162,6 +174,9 @@ async function runFuzzTarget(
       crashFiles: [crash.jsonPath],
       seed: config.seed,
       time: Date.now() - startedAt,
+      buildTime,
+      buildStartedAt,
+      buildFinishedAt,
       fuzzers: [],
     };
   }
@@ -186,6 +201,9 @@ async function runFuzzTarget(
       crashFiles: [crash.jsonPath],
       seed: config.seed,
       time: Date.now() - startedAt,
+      buildTime,
+      buildStartedAt,
+      buildFinishedAt,
       fuzzers: [],
     };
   }
@@ -199,6 +217,9 @@ async function runFuzzTarget(
     crashFiles: [],
     seed: config.seed,
     time: Date.now() - startedAt,
+    buildTime,
+    buildStartedAt,
+    buildFinishedAt,
     fuzzers: report.fuzzers,
   };
 }

--- a/cli/commands/fuzz.ts
+++ b/cli/commands/fuzz.ts
@@ -7,6 +7,7 @@ export type FuzzFlags = {
 type FuzzCommandDeps = {
   resolveCommandArgs(rawArgs: string[], command: string): string[];
   resolveListFlags(rawArgs: string[], command: string): CliListFlags;
+  resolveJobs(rawArgs: string[], command: "fuzz"): number;
   resolveExecutionModes(
     configPath: string | undefined,
     selectedModes: string[],

--- a/cli/commands/init-core.ts
+++ b/cli/commands/init-core.ts
@@ -740,6 +740,9 @@ function applyInit(
   if (!scripts.test) {
     scripts.test = "ast test";
   }
+  if (fuzzExample && !scripts.fuzz) {
+    scripts.fuzz = "ast fuzz";
+  }
 
   if (!pkg.type) {
     pkg.type = "module";
@@ -1206,20 +1209,18 @@ function resolveInstallCommand(root: string): {
 }
 
 function buildMinimalExampleSpec(): string {
-  return `import { describe, expect, test, run } from "as-test";
+  return `import { describe, expect, test } from "as-test";
 
 describe("example", () => {
   test("adds numbers", () => {
     expect(1 + 2).toBe(3);
   });
 });
-
-run();
 `;
 }
 
 function buildFullExampleSpec(): string {
-  return `import { afterAll, beforeAll, describe, expect, it, log, run, test } from "as-test";
+  return `import { afterAll, beforeAll, describe, expect, it, log, test } from "as-test";
 
 beforeAll(() => {
   log("setup");
@@ -1249,8 +1250,6 @@ describe("strings", () => {
     expect("as-test").toStartWith("as");
   });
 });
-
-run();
 `;
 }
 

--- a/cli/commands/run-core.ts
+++ b/cli/commands/run-core.ts
@@ -70,6 +70,7 @@ type ReporterConfigObject = {
 export type RunResult = {
   failed: boolean;
   stats: RunStats;
+  buildTime: number;
   snapshotSummary: {
     matched: number;
     created: number;
@@ -854,6 +855,7 @@ export async function run(
       clean: cleanOutput,
       snapshotEnabled,
       showCoverage,
+      buildTime: 0,
       snapshotSummary,
       coverageSummary,
       stats,
@@ -874,6 +876,7 @@ export async function run(
   }
   return {
     failed,
+    buildTime: 0,
     stats,
     snapshotSummary,
     coverageSummary,

--- a/cli/commands/run-core.ts
+++ b/cli/commands/run-core.ts
@@ -2049,6 +2049,10 @@ export async function createRunReporter(
   configPath: string = DEFAULT_CONFIG_PATH,
   reporterPath?: string,
   modeName?: string,
+  context: ReporterContext = {
+    stdout: process.stdout,
+    stderr: process.stderr,
+  },
 ): Promise<{
   reporter: TestReporter;
   reporterKind: ReporterKind;
@@ -2064,8 +2068,8 @@ export async function createRunReporter(
     config.runOptions.reporter,
   );
   const reporter = await loadReporter(selection, resolvedConfigPath, {
-    stdout: process.stdout,
-    stderr: process.stderr,
+    stdout: context.stdout,
+    stderr: context.stderr,
   });
   const runtimeCommand = resolveRuntimeCommand(
     getConfiguredRuntimeCmd(config),

--- a/cli/commands/run.ts
+++ b/cli/commands/run.ts
@@ -7,6 +7,14 @@ type RunCommandDeps = {
   resolveCommandArgs(rawArgs: string[], command: string): string[];
   resolveListFlags(rawArgs: string[], command: string): CliListFlags;
   resolveFeatureToggles(rawArgs: string[], command: string): CliFeatureToggles;
+  resolveParallelJobs(
+    rawArgs: string[],
+    command: "run",
+  ): {
+    jobs: number;
+    buildJobs: number;
+    runJobs: number;
+  };
   resolveBrowserOverride(rawArgs: string[], command: "run"): string | undefined;
   resolveExecutionModes(
     configPath: string | undefined,
@@ -44,6 +52,7 @@ export async function executeRunCommand(
     clean: flags.includes("--clean"),
     showCoverage: flags.includes("--show-coverage"),
     verbose: flags.includes("--verbose"),
+    ...deps.resolveParallelJobs(rawArgs, "run"),
     coverage: featureToggles.coverage,
     browser: deps.resolveBrowserOverride(rawArgs, "run"),
   };

--- a/cli/commands/test.ts
+++ b/cli/commands/test.ts
@@ -6,6 +6,14 @@ type TestCommandDeps = {
   resolveCommandArgs(rawArgs: string[], command: string): string[];
   resolveListFlags(rawArgs: string[], command: string): CliListFlags;
   resolveFeatureToggles(rawArgs: string[], command: string): CliFeatureToggles;
+  resolveParallelJobs(
+    rawArgs: string[],
+    command: "test",
+  ): {
+    jobs: number;
+    buildJobs: number;
+    runJobs: number;
+  };
   resolveBrowserOverride(
     rawArgs: string[],
     command: "test",
@@ -58,6 +66,7 @@ export async function executeTestCommand(
     clean: flags.includes("--clean"),
     showCoverage: flags.includes("--show-coverage"),
     verbose: flags.includes("--verbose"),
+    ...deps.resolveParallelJobs(rawArgs, "test"),
     coverage: featureToggles.coverage,
     browser: deps.resolveBrowserOverride(rawArgs, "test"),
   };

--- a/cli/commands/types.ts
+++ b/cli/commands/types.ts
@@ -15,6 +15,9 @@ export type RunFlags = {
   clean: boolean;
   showCoverage: boolean;
   verbose: boolean;
+  jobs: number;
+  buildJobs: number;
+  runJobs: number;
   coverage?: boolean;
   browser?: string;
 };

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -28,6 +28,7 @@ import { spawnSync } from "child_process";
 import { glob } from "glob";
 import { createInterface } from "readline";
 import { existsSync } from "fs";
+import { availableParallelism, cpus } from "os";
 import {
   CoverageSummary,
   FuzzCompleteEvent,
@@ -243,9 +244,15 @@ function info(): void {
   );
   console.log(
     "   " +
+      chalk.bold.blue("--parallel") +
+      "                     " +
+      "Run files through an ordered worker pool using an automatic worker count",
+  );
+  console.log(
+    "   " +
       chalk.bold.blue("--jobs <n>") +
       "                     " +
-      "Run files through an ordered worker pool",
+      "Run files through an ordered worker pool with an explicit worker count",
   );
   console.log(
     "   " +
@@ -419,6 +426,9 @@ function printCommandHelp(command: string): void {
       "  --browser <name|path>    Use chrome, chromium, firefox, webkit, or an executable path for web modes\n",
     );
     process.stdout.write(
+      "  --parallel              Run files through an ordered worker pool using an automatic worker count\n",
+    );
+    process.stdout.write(
       "  --jobs <n>               Run files through an ordered worker pool\n",
     );
     process.stdout.write(
@@ -485,6 +495,9 @@ function printCommandHelp(command: string): void {
       "  --browser <name|path>    Use chrome, chromium, firefox, webkit, or an executable path for web modes\n",
     );
     process.stdout.write(
+      "  --parallel              Run files through an ordered worker pool using an automatic worker count\n",
+    );
+    process.stdout.write(
       "  --jobs <n>               Run files through an ordered worker pool\n",
     );
     process.stdout.write(
@@ -519,6 +532,9 @@ function printCommandHelp(command: string): void {
     );
     process.stdout.write(
       "  --fuzz-seed <n>          Override fuzz seed for this run\n",
+    );
+    process.stdout.write(
+      "  --parallel              Run files through an ordered worker pool using an automatic worker count\n",
     );
     process.stdout.write(
       "  --jobs <n>               Run files through an ordered worker pool\n",
@@ -705,6 +721,7 @@ function resolveCommandArgs(rawArgs: string[], command: string): string[] {
     if (
       arg == "--runs" ||
       arg == "--seed" ||
+      arg == "--parallel" ||
       arg == "--jobs" ||
       arg == "--build-jobs" ||
       arg == "--run-jobs" ||
@@ -913,10 +930,15 @@ function resolveJobs(
   command: "run" | "test" | "fuzz",
 ): number {
   let seenCommand = false;
+  let parallel = false;
   for (let i = 0; i < rawArgs.length; i++) {
     const arg = rawArgs[i]!;
     if (!seenCommand) {
       if (arg == command) seenCommand = true;
+      continue;
+    }
+    if (arg == "--parallel") {
+      parallel = true;
       continue;
     }
     const parsed = parseNumberFlag(rawArgs, i, "--jobs");
@@ -926,7 +948,7 @@ function resolveJobs(
     }
     return parsed.number;
   }
-  return 1;
+  return parallel ? 0 : 1;
 }
 
 function resolveParallelJobs(
@@ -1004,6 +1026,42 @@ function resolveFuzzParallelJobs(rawArgs: string[]): {
   }
   const jobs = Math.max(baseJobs, buildJobs, runJobs);
   return { jobs, buildJobs, runJobs };
+}
+
+function resolveEffectiveParallelJobs(
+  settings: { jobs: number; buildJobs: number; runJobs: number },
+  totalFiles: number,
+): {
+  jobs: number;
+  buildJobs: number;
+  runJobs: number;
+} {
+  if (settings.jobs > 0) {
+    return {
+      jobs: Math.max(settings.jobs, settings.buildJobs, settings.runJobs),
+      buildJobs: settings.buildJobs > 0 ? settings.buildJobs : settings.jobs,
+      runJobs: settings.runJobs > 0 ? settings.runJobs : settings.jobs,
+    };
+  }
+  const autoJobs = resolveAutoJobs(totalFiles);
+  return {
+    jobs: Math.max(autoJobs, settings.buildJobs, settings.runJobs),
+    buildJobs: settings.buildJobs > 0 ? settings.buildJobs : autoJobs,
+    runJobs: settings.runJobs > 0 ? settings.runJobs : autoJobs,
+  };
+}
+
+function resolveAutoJobs(totalFiles: number): number {
+  const cpuCount =
+    typeof availableParallelism == "function"
+      ? availableParallelism()
+      : cpus().length;
+  const cpuBudget = Math.max(1, cpuCount - 1);
+  if (totalFiles <= 1) return 1;
+  if (totalFiles <= 4) return Math.min(2, cpuBudget, totalFiles);
+  if (totalFiles <= 12) return Math.min(3, cpuBudget);
+  if (totalFiles <= 32) return Math.min(4, cpuBudget);
+  return Math.min(Math.max(4, Math.ceil(totalFiles / 12)), cpuBudget);
 }
 
 type BufferedStream = NodeJS.WritableStream & {
@@ -1226,6 +1284,7 @@ async function runTestSequential(
 ): Promise<{
   failed: boolean;
   summary: {
+    buildTime: number;
     snapshotSummary: {
       matched: number;
       created: number;
@@ -1261,9 +1320,12 @@ async function runTestSequential(
 
   const results: RunResult[] = [];
   let failed = false;
+  const buildIntervals: Array<{ start: number; end: number }> = [];
   const duplicateSpecBasenames = resolveDuplicateSpecBasenames(files);
   for (const file of files) {
+    const buildStartedAt = Date.now();
     await build(configPath, [file], modeName, buildFeatureToggles);
+    buildIntervals.push({ start: buildStartedAt, end: Date.now() });
     const buildInvocation = await getBuildInvocationPreview(
       configPath,
       file,
@@ -1294,6 +1356,7 @@ async function runTestSequential(
       clean: runFlags.clean,
       snapshotEnabled,
       showCoverage: runFlags.showCoverage,
+      buildTime: getMergedIntervalDuration(buildIntervals),
       snapshotSummary: summary.snapshotSummary,
       coverageSummary: summary.coverageSummary,
       stats: summary.stats,
@@ -1309,6 +1372,7 @@ async function runTestSequential(
   return {
     failed,
     summary: {
+      buildTime: getMergedIntervalDuration(buildIntervals),
       snapshotSummary: summary.snapshotSummary,
       coverageSummary: summary.coverageSummary,
       stats: summary.stats,
@@ -1349,10 +1413,14 @@ async function runRuntimeModes(
   await ensureWebBrowsersReady(configPath, modes, runFlags.browser);
   const modeSummaryTotal = Math.max(modes.length, 1);
   const fileSummaryTotal = await resolveConfiguredFileTotal(configPath);
-  if (runFlags.jobs > 1) {
+  const effectiveRunFlags = {
+    ...runFlags,
+    ...resolveEffectiveParallelJobs(runFlags, fileSummaryTotal),
+  };
+  if (effectiveRunFlags.jobs > 1) {
     if (modes.length > 1) {
       const failed = await runRuntimeMatrixParallel(
-        runFlags,
+        effectiveRunFlags,
         configPath,
         selectors,
         modes,
@@ -1365,7 +1433,7 @@ async function runRuntimeModes(
     let failed = false;
     for (const modeName of modes) {
       const result = await runRuntimeSingleParallel(
-        runFlags,
+        effectiveRunFlags,
         configPath,
         selectors,
         modeName,
@@ -1379,7 +1447,7 @@ async function runRuntimeModes(
   }
   if (modes.length > 1) {
     const failed = await runRuntimeMatrix(
-      runFlags,
+      effectiveRunFlags,
       configPath,
       selectors,
       modes,
@@ -1398,7 +1466,7 @@ async function runRuntimeModes(
     {},
   );
   for (const modeName of modes) {
-    const result = await run(runFlags, configPath, selectors, false, {
+    const result = await run(effectiveRunFlags, configPath, selectors, false, {
       modeName,
       modeSummaryTotal,
       modeSummaryExecuted: 1,
@@ -1460,6 +1528,7 @@ async function runRuntimeMatrix(
     passed: false,
   }));
   const duplicateSpecBasenames = resolveDuplicateSpecBasenames(files);
+  const buildIntervals: Array<{ start: number; end: number }> = [];
 
   for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
     const file = files[fileIndex]!;
@@ -1539,6 +1608,7 @@ async function runRuntimeMatrix(
     clean: runFlags.clean,
     snapshotEnabled,
     showCoverage: runFlags.showCoverage,
+    buildTime: 0,
     snapshotSummary: summary.snapshotSummary,
     coverageSummary: summary.coverageSummary,
     stats: summary.stats,
@@ -1575,10 +1645,14 @@ async function runTestModes(
     configPath,
     selectors,
   );
-  if (runFlags.jobs > 1) {
+  const effectiveRunFlags = {
+    ...runFlags,
+    ...resolveEffectiveParallelJobs(runFlags, fileSummaryTotal),
+  };
+  if (effectiveRunFlags.jobs > 1) {
     if (modes.length > 1) {
       const failed = await runTestMatrixParallel(
-        runFlags,
+        effectiveRunFlags,
         configPath,
         selectors,
         modes,
@@ -1594,7 +1668,7 @@ async function runTestModes(
     let failed = false;
     for (const modeName of modes) {
       const modeFailed = await runTestSingleParallel(
-        runFlags,
+        effectiveRunFlags,
         configPath,
         selectors,
         buildFeatureToggles,
@@ -1611,7 +1685,7 @@ async function runTestModes(
   }
   if (modes.length > 1) {
     const failed = await runTestMatrix(
-      runFlags,
+      effectiveRunFlags,
       configPath,
       selectors,
       modes,
@@ -1633,7 +1707,7 @@ async function runTestModes(
       modeName,
     );
     const modeResult = await runTestSequential(
-      runFlags,
+      effectiveRunFlags,
       configPath,
       selectors,
       buildFeatureToggles,
@@ -1659,8 +1733,11 @@ async function runTestModes(
       if (fuzzResults.some(hasFuzzFailures)) failed = true;
       reporterSession.reporter.onRunComplete?.({
         clean: runFlags.clean,
-        snapshotEnabled: runFlags.snapshot !== false,
-        showCoverage: runFlags.showCoverage,
+        snapshotEnabled: effectiveRunFlags.snapshot !== false,
+        showCoverage: effectiveRunFlags.showCoverage,
+        buildTime:
+          modeResult.summary.buildTime +
+          getMergedIntervalDuration(collectFuzzBuildIntervals(fuzzResults)),
         snapshotSummary: modeResult.summary.snapshotSummary,
         coverageSummary: modeResult.summary.coverageSummary,
         stats: modeResult.summary.stats,
@@ -1737,6 +1814,7 @@ async function runTestMatrix(
     passed: false,
   }));
   const duplicateSpecBasenames = resolveDuplicateSpecBasenames(files);
+  const buildIntervals: Array<{ start: number; end: number }> = [];
 
   for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
     const file = files[fileIndex]!;
@@ -1749,7 +1827,9 @@ async function runTestMatrix(
     for (let i = 0; i < modes.length; i++) {
       const modeName = modes[i];
       try {
+        const buildStartedAt = Date.now();
         await build(configPath, [file], modeName, buildFeatureToggles);
+        buildIntervals.push({ start: buildStartedAt, end: Date.now() });
         const buildInvocation = await getBuildInvocationPreview(
           configPath,
           file,
@@ -1834,11 +1914,13 @@ async function runTestMatrix(
     );
     if (fuzzResults.some(hasFuzzFailures)) failed = true;
     fuzzSummary = summarizeFuzzExecutions(fuzzResults);
+    buildIntervals.push(...collectFuzzBuildIntervals(fuzzResults));
   }
   reporter.onRunComplete?.({
     clean: runFlags.clean,
     snapshotEnabled,
     showCoverage: runFlags.showCoverage,
+    buildTime: getMergedIntervalDuration(buildIntervals),
     snapshotSummary: summary.snapshotSummary,
     coverageSummary: summary.coverageSummary,
     stats: summary.stats,
@@ -1857,8 +1939,13 @@ async function runFuzzModes(
   rawArgs: string[],
 ): Promise<void> {
   const overrides = resolveFuzzOverrides(rawArgs, "fuzz");
-  const { jobs, buildJobs, runJobs } = resolveFuzzParallelJobs(rawArgs);
+  const parallelSettings = resolveFuzzParallelJobs(rawArgs);
   const clean = rawArgs.includes("--clean");
+  const fuzzFiles = await resolveSelectedFuzzFiles(configPath, selectors);
+  const { jobs, buildJobs, runJobs } = resolveEffectiveParallelJobs(
+    parallelSettings,
+    fuzzFiles.length,
+  );
   if (jobs > 1) {
     const results = await runFuzzMatrixResultsParallel(
       configPath,
@@ -1970,6 +2057,7 @@ async function runRuntimeSingleParallel(
     clean: runFlags.clean,
     snapshotEnabled,
     showCoverage: runFlags.showCoverage,
+    buildTime: 0,
     snapshotSummary: summary.snapshotSummary,
     coverageSummary: summary.coverageSummary,
     stats: summary.stats,
@@ -2033,6 +2121,7 @@ async function runRuntimeMatrixParallel(
     runFlags.runJobs,
   );
   const buildPool = new BuildWorkerPool(runFlags.buildJobs);
+  const buildIntervals: Array<{ start: number; end: number }> = [];
   try {
     await runOrderedPool(files, poolWidth, async (file, fileIndex) => {
       const fileName = path.basename(file);
@@ -2041,11 +2130,13 @@ async function runRuntimeMatrixParallel(
       const modeTimes = modes.map(() => "...");
       for (let i = 0; i < modes.length; i++) {
         const modeName = modes[i];
+        const buildStartedAt = Date.now();
         await buildPool.buildFileMode({
           configPath,
           file,
           modeName,
         });
+        buildIntervals.push({ start: buildStartedAt, end: Date.now() });
         const buildInvocation = await getBuildInvocationPreview(
           configPath,
           file,
@@ -2110,6 +2201,7 @@ async function runRuntimeMatrixParallel(
     clean: runFlags.clean,
     snapshotEnabled,
     showCoverage: runFlags.showCoverage,
+    buildTime: getMergedIntervalDuration(buildIntervals),
     snapshotSummary: summary.snapshotSummary,
     coverageSummary: summary.coverageSummary,
     stats: summary.stats,
@@ -2169,17 +2261,20 @@ async function runTestSingleParallel(
     runFlags.buildJobs,
     runFlags.runJobs,
   );
+  const buildIntervals: Array<{ start: number; end: number }> = [];
   if (files.length) {
     const buildPool = new BuildWorkerPool(runFlags.buildJobs);
     try {
       await runOrderedPool(files, poolWidth, async (file, index) => {
         const token = renderQueuedFileStart(queueDisplay, path.basename(file));
+        const buildStartedAt = Date.now();
         await buildPool.buildFileMode({
           configPath,
           file,
           modeName,
           featureToggles: buildFeatureToggles,
         });
+        buildIntervals.push({ start: buildStartedAt, end: Date.now() });
         const buildInvocation = await getBuildInvocationPreview(
           configPath,
           file,
@@ -2245,11 +2340,13 @@ async function runTestSingleParallel(
     );
     if (fuzzResults.some(hasFuzzFailures)) failed = true;
     fuzzSummary = summarizeFuzzExecutions(fuzzResults);
+    buildIntervals.push(...collectFuzzBuildIntervals(fuzzResults));
   }
   reporter.onRunComplete?.({
     clean: runFlags.clean,
     snapshotEnabled,
     showCoverage: runFlags.showCoverage,
+    buildTime: getMergedIntervalDuration(buildIntervals),
     snapshotSummary: summary.snapshotSummary,
     coverageSummary: summary.coverageSummary,
     stats: summary.stats,
@@ -2323,6 +2420,7 @@ async function runTestMatrixParallel(
     runFlags.runJobs,
   );
   const buildPool = new BuildWorkerPool(runFlags.buildJobs);
+  const buildIntervals: Array<{ start: number; end: number }> = [];
   try {
     await runOrderedPool(files, poolWidth, async (file, fileIndex) => {
       const fileName = path.basename(file);
@@ -2331,12 +2429,14 @@ async function runTestMatrixParallel(
       const modeTimes = modes.map(() => "...");
       for (let i = 0; i < modes.length; i++) {
         const modeName = modes[i];
+        const buildStartedAt = Date.now();
         await buildPool.buildFileMode({
           configPath,
           file,
           modeName,
           featureToggles: buildFeatureToggles,
         });
+        buildIntervals.push({ start: buildStartedAt, end: Date.now() });
         const buildInvocation = await getBuildInvocationPreview(
           configPath,
           file,
@@ -2421,11 +2521,13 @@ async function runTestMatrixParallel(
     );
     if (fuzzResults.some(hasFuzzFailures)) failed = true;
     fuzzSummary = summarizeFuzzExecutions(fuzzResults);
+    buildIntervals.push(...collectFuzzBuildIntervals(fuzzResults));
   }
   reporter.onRunComplete?.({
     clean: runFlags.clean,
     snapshotEnabled,
     showCoverage: runFlags.showCoverage,
+    buildTime: getMergedIntervalDuration(buildIntervals),
     snapshotSummary: summary.snapshotSummary,
     coverageSummary: summary.coverageSummary,
     stats: summary.stats,
@@ -2511,10 +2613,47 @@ function buildFuzzCompleteEvent(
   return {
     results,
     time: results.reduce((sum, item) => sum + item.time, 0),
+    buildTime: getMergedIntervalDuration(collectFuzzBuildIntervals(results)),
     fuzzingSummary: summarizeFuzzExecutions(results),
     suiteSummary: summarizeFuzzSuites(results),
     modeSummary: summarizeFuzzModes(results, modes),
   };
+}
+
+function collectFuzzBuildIntervals(
+  results: FuzzResult[],
+): Array<{ start: number; end: number }> {
+  return results.map((result) => ({
+    start: result.buildStartedAt,
+    end: result.buildFinishedAt,
+  }));
+}
+
+function getMergedIntervalDuration(
+  intervals: Array<{ start: number; end: number }>,
+): number {
+  if (!intervals.length) return 0;
+  const sorted = intervals
+    .map((interval) => ({
+      start: Math.min(interval.start, interval.end),
+      end: Math.max(interval.start, interval.end),
+    }))
+    .sort((a, b) => a.start - b.start);
+  let total = 0;
+  let currentStart = sorted[0]!.start;
+  let currentEnd = sorted[0]!.end;
+  for (let i = 1; i < sorted.length; i++) {
+    const interval = sorted[i]!;
+    if (interval.start <= currentEnd) {
+      currentEnd = Math.max(currentEnd, interval.end);
+      continue;
+    }
+    total += currentEnd - currentStart;
+    currentStart = interval.start;
+    currentEnd = interval.end;
+  }
+  total += currentEnd - currentStart;
+  return total;
 }
 
 function summarizeFuzzExecutions(results: FuzzResult[]): {

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -35,6 +35,7 @@ import {
   RunStats,
   TestReporter,
 } from "./reporters/types.js";
+import { BuildWorkerPool } from "./build-worker-pool.js";
 
 const _args = process.argv.slice(2);
 const flags: string[] = [];
@@ -88,6 +89,7 @@ if (!args.length) {
         resolveCommandArgs,
         resolveListFlags,
         resolveFeatureToggles,
+        resolveParallelJobs,
         resolveBrowserOverride,
         resolveExecutionModes,
         listExecutionPlan,
@@ -101,6 +103,7 @@ if (!args.length) {
         resolveCommandArgs,
         resolveListFlags,
         resolveFeatureToggles,
+        resolveParallelJobs,
         resolveBrowserOverride,
         resolveFuzzOverrides,
         resolveExecutionModes,
@@ -114,6 +117,7 @@ if (!args.length) {
       executeFuzzCommand(_args, configPath, selectedModes, {
         resolveCommandArgs,
         resolveListFlags,
+        resolveJobs,
         resolveExecutionModes,
         listExecutionPlan,
         runFuzzModes,
@@ -236,6 +240,24 @@ function info(): void {
       chalk.bold.blue("--browser <name|path>") +
       "        " +
       "Use chrome, chromium, firefox, webkit, or an executable path for web modes",
+  );
+  console.log(
+    "   " +
+      chalk.bold.blue("--jobs <n>") +
+      "                     " +
+      "Run files through an ordered worker pool",
+  );
+  console.log(
+    "   " +
+      chalk.bold.blue("--build-jobs <n>") +
+      "               " +
+      "Limit concurrent build tasks (defaults to --jobs)",
+  );
+  console.log(
+    "   " +
+      chalk.bold.blue("--run-jobs <n>") +
+      "                 " +
+      "Limit concurrent run tasks (defaults to --jobs)",
   );
   console.log(
     "   " +
@@ -397,6 +419,15 @@ function printCommandHelp(command: string): void {
       "  --browser <name|path>    Use chrome, chromium, firefox, webkit, or an executable path for web modes\n",
     );
     process.stdout.write(
+      "  --jobs <n>               Run files through an ordered worker pool\n",
+    );
+    process.stdout.write(
+      "  --build-jobs <n>         Limit concurrent build tasks (defaults to --jobs)\n",
+    );
+    process.stdout.write(
+      "  --run-jobs <n>           Limit concurrent run tasks (defaults to --jobs)\n",
+    );
+    process.stdout.write(
       "  --create-snapshots       Create missing snapshot entries\n",
     );
     process.stdout.write(
@@ -454,6 +485,15 @@ function printCommandHelp(command: string): void {
       "  --browser <name|path>    Use chrome, chromium, firefox, webkit, or an executable path for web modes\n",
     );
     process.stdout.write(
+      "  --jobs <n>               Run files through an ordered worker pool\n",
+    );
+    process.stdout.write(
+      "  --build-jobs <n>         Limit concurrent build tasks (defaults to --jobs)\n",
+    );
+    process.stdout.write(
+      "  --run-jobs <n>           Limit concurrent run tasks (defaults to --jobs)\n",
+    );
+    process.stdout.write(
       "  --create-snapshots       Create missing snapshot entries\n",
     );
     process.stdout.write(
@@ -479,6 +519,15 @@ function printCommandHelp(command: string): void {
     );
     process.stdout.write(
       "  --fuzz-seed <n>          Override fuzz seed for this run\n",
+    );
+    process.stdout.write(
+      "  --jobs <n>               Run files through an ordered worker pool\n",
+    );
+    process.stdout.write(
+      "  --build-jobs <n>         Limit concurrent build tasks (defaults to --jobs)\n",
+    );
+    process.stdout.write(
+      "  --run-jobs <n>           Limit concurrent run tasks (defaults to --jobs)\n",
     );
     process.stdout.write(
       "  --reporter <name|path>   Use built-in reporter (default|tap) or custom module path\n",
@@ -520,6 +569,15 @@ function printCommandHelp(command: string): void {
       "  --runs <n>               Override fuzz iteration count\n",
     );
     process.stdout.write("  --seed <n>               Override fuzz seed\n");
+    process.stdout.write(
+      "  --jobs <n>               Run files through an ordered worker pool\n",
+    );
+    process.stdout.write(
+      "  --build-jobs <n>         Limit concurrent build tasks (defaults to --jobs)\n",
+    );
+    process.stdout.write(
+      "  --run-jobs <n>           Limit concurrent run tasks (defaults to --jobs)\n",
+    );
     process.stdout.write(
       "  --list                   Preview resolved fuzz files without running\n",
     );
@@ -647,6 +705,9 @@ function resolveCommandArgs(rawArgs: string[], command: string): string[] {
     if (
       arg == "--runs" ||
       arg == "--seed" ||
+      arg == "--jobs" ||
+      arg == "--build-jobs" ||
+      arg == "--run-jobs" ||
       arg == "--browser" ||
       arg == "--fuzz-runs" ||
       arg == "--fuzz-seed"
@@ -657,6 +718,9 @@ function resolveCommandArgs(rawArgs: string[], command: string): string[] {
     if (
       arg.startsWith("--runs=") ||
       arg.startsWith("--seed=") ||
+      arg.startsWith("--jobs=") ||
+      arg.startsWith("--build-jobs=") ||
+      arg.startsWith("--run-jobs=") ||
       arg.startsWith("--browser=") ||
       arg.startsWith("--fuzz-runs=") ||
       arg.startsWith("--fuzz-seed=")
@@ -844,6 +908,261 @@ function resolveBrowserOverride(
   return undefined;
 }
 
+function resolveJobs(
+  rawArgs: string[],
+  command: "run" | "test" | "fuzz",
+): number {
+  let seenCommand = false;
+  for (let i = 0; i < rawArgs.length; i++) {
+    const arg = rawArgs[i]!;
+    if (!seenCommand) {
+      if (arg == command) seenCommand = true;
+      continue;
+    }
+    const parsed = parseNumberFlag(rawArgs, i, "--jobs");
+    if (!parsed) continue;
+    if (parsed.number < 1) {
+      throw new Error("--jobs requires a positive integer");
+    }
+    return parsed.number;
+  }
+  return 1;
+}
+
+function resolveParallelJobs(
+  rawArgs: string[],
+  command: "run" | "test",
+): {
+  jobs: number;
+  buildJobs: number;
+  runJobs: number;
+} {
+  const baseJobs = resolveJobs(rawArgs, command);
+  let buildJobs = baseJobs;
+  let runJobs = baseJobs;
+
+  let seenCommand = false;
+  for (let i = 0; i < rawArgs.length; i++) {
+    const arg = rawArgs[i]!;
+    if (!seenCommand) {
+      if (arg == command) seenCommand = true;
+      continue;
+    }
+    const buildParsed = parseNumberFlag(rawArgs, i, "--build-jobs");
+    if (buildParsed) {
+      if (buildParsed.number < 1) {
+        throw new Error("--build-jobs requires a positive integer");
+      }
+      buildJobs = buildParsed.number;
+      continue;
+    }
+    const runParsed = parseNumberFlag(rawArgs, i, "--run-jobs");
+    if (runParsed) {
+      if (runParsed.number < 1) {
+        throw new Error("--run-jobs requires a positive integer");
+      }
+      runJobs = runParsed.number;
+      continue;
+    }
+  }
+  const jobs = Math.max(baseJobs, buildJobs, runJobs);
+  return { jobs, buildJobs, runJobs };
+}
+
+function resolveFuzzParallelJobs(rawArgs: string[]): {
+  jobs: number;
+  buildJobs: number;
+  runJobs: number;
+} {
+  const baseJobs = resolveJobs(rawArgs, "fuzz");
+  let buildJobs = baseJobs;
+  let runJobs = baseJobs;
+
+  let seenCommand = false;
+  for (let i = 0; i < rawArgs.length; i++) {
+    const arg = rawArgs[i]!;
+    if (!seenCommand) {
+      if (arg == "fuzz") seenCommand = true;
+      continue;
+    }
+    const buildParsed = parseNumberFlag(rawArgs, i, "--build-jobs");
+    if (buildParsed) {
+      if (buildParsed.number < 1) {
+        throw new Error("--build-jobs requires a positive integer");
+      }
+      buildJobs = buildParsed.number;
+      continue;
+    }
+    const runParsed = parseNumberFlag(rawArgs, i, "--run-jobs");
+    if (runParsed) {
+      if (runParsed.number < 1) {
+        throw new Error("--run-jobs requires a positive integer");
+      }
+      runJobs = runParsed.number;
+      continue;
+    }
+  }
+  const jobs = Math.max(baseJobs, buildJobs, runJobs);
+  return { jobs, buildJobs, runJobs };
+}
+
+type BufferedStream = NodeJS.WritableStream & {
+  isTTY?: boolean;
+  read(): string;
+};
+
+function createBufferedStream(): BufferedStream {
+  const chunks: string[] = [];
+  return {
+    isTTY: false,
+    write(chunk: string | Uint8Array): boolean {
+      chunks.push(
+        typeof chunk == "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+      );
+      return true;
+    },
+    read(): string {
+      return chunks.join("");
+    },
+  } as BufferedStream;
+}
+
+async function createBufferedReporter(
+  configPath: string | undefined,
+  modeName?: string,
+): Promise<{
+  reporter: TestReporter;
+  reporterKind: "default" | "tap" | "custom";
+  runtimeName: string;
+  output(): string;
+}> {
+  const stream = createBufferedStream();
+  const session = await createRunReporter(configPath, undefined, modeName, {
+    stdout: stream,
+    stderr: stream,
+  });
+  return {
+    reporter: session.reporter,
+    reporterKind: session.reporterKind,
+    runtimeName: session.runtimeName,
+    output: () => stream.read(),
+  };
+}
+
+async function runOrderedPool<T>(
+  items: T[],
+  jobs: number,
+  worker: (item: T, index: number) => Promise<void>,
+): Promise<void> {
+  const width = Math.max(1, jobs);
+  let nextIndex = 0;
+  let firstError: unknown = null;
+
+  async function runWorker(): Promise<void> {
+    while (true) {
+      if (firstError != null) return;
+      const index = nextIndex++;
+      if (index >= items.length) return;
+      try {
+        await worker(items[index]!, index);
+      } catch (error) {
+        if (firstError == null) firstError = error;
+        return;
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(width, items.length) }, () => runWorker()),
+  );
+  if (firstError != null) throw firstError;
+}
+
+function createAsyncLimiter(limit: number) {
+  const width = Math.max(1, limit);
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  return async function withLimit<T>(task: () => Promise<T>): Promise<T> {
+    if (active >= width) {
+      await new Promise<void>((resolve) => queue.push(resolve));
+    }
+    active++;
+    try {
+      return await task();
+    } finally {
+      active--;
+      const next = queue.shift();
+      if (next) next();
+    }
+  };
+}
+
+function canRewriteParallelQueue(): boolean {
+  return Boolean((process.stdout as { isTTY?: boolean }).isTTY);
+}
+
+class ParallelQueueDisplay {
+  private readonly enabled: boolean;
+  private readonly active = new Map<symbol, string>();
+  private renderedLines = 0;
+
+  constructor(private readonly showStartLines: boolean) {
+    this.enabled = showStartLines && canRewriteParallelQueue();
+  }
+
+  start(file: string): symbol {
+    const token = Symbol(file);
+    if (!this.showStartLines) return token;
+    const line = `${chalk.bgBlackBright.white(" .... ")} ${file}`;
+    if (!this.enabled) return token;
+    this.clear();
+    this.active.set(token, line);
+    this.render();
+    return token;
+  }
+
+  complete(token: symbol, output: string): void {
+    if (!this.showStartLines || !this.enabled) {
+      process.stdout.write(output);
+      return;
+    }
+    this.clear();
+    process.stdout.write(output);
+    this.active.delete(token);
+    this.render();
+  }
+
+  flush(): void {
+    if (!this.enabled) return;
+    this.clear();
+  }
+
+  private clear(): void {
+    if (!this.renderedLines) return;
+    for (let i = 0; i < this.renderedLines; i++) {
+      process.stdout.write("\r\x1b[2K");
+      if (i < this.renderedLines - 1) process.stdout.write("\x1b[1A");
+    }
+    this.renderedLines = 0;
+  }
+
+  private render(): void {
+    if (!this.enabled) return;
+    const lines = Array.from(this.active.values());
+    if (!lines.length) return;
+    process.stdout.write(lines.join("\n"));
+    this.renderedLines = lines.length;
+  }
+}
+
+function renderQueuedFileStart(
+  display: ParallelQueueDisplay,
+  file: string,
+): symbol {
+  return display.start(file);
+}
+
 function parseIntegerFlag(flag: string, value: string): number {
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed < 0) {
@@ -1017,6 +1336,9 @@ async function runRuntimeModes(
     clean: boolean;
     showCoverage: boolean;
     verbose: boolean;
+    jobs: number;
+    buildJobs: number;
+    runJobs: number;
     coverage?: boolean;
     browser?: string;
   },
@@ -1025,8 +1347,36 @@ async function runRuntimeModes(
   modes: (string | undefined)[],
 ): Promise<void> {
   await ensureWebBrowsersReady(configPath, modes, runFlags.browser);
-  const modeSummaryTotal = resolveConfiguredModeTotal(configPath);
+  const modeSummaryTotal = Math.max(modes.length, 1);
   const fileSummaryTotal = await resolveConfiguredFileTotal(configPath);
+  if (runFlags.jobs > 1) {
+    if (modes.length > 1) {
+      const failed = await runRuntimeMatrixParallel(
+        runFlags,
+        configPath,
+        selectors,
+        modes,
+        modeSummaryTotal,
+        fileSummaryTotal,
+      );
+      process.exit(failed ? 1 : 0);
+      return;
+    }
+    let failed = false;
+    for (const modeName of modes) {
+      const result = await runRuntimeSingleParallel(
+        runFlags,
+        configPath,
+        selectors,
+        modeName,
+        modeSummaryTotal,
+        fileSummaryTotal,
+      );
+      if (result) failed = true;
+    }
+    process.exit(failed ? 1 : 0);
+    return;
+  }
   if (modes.length > 1) {
     const failed = await runRuntimeMatrix(
       runFlags,
@@ -1068,6 +1418,9 @@ async function runRuntimeMatrix(
     clean: boolean;
     showCoverage: boolean;
     verbose: boolean;
+    jobs: number;
+    buildJobs: number;
+    runJobs: number;
     coverage?: boolean;
   },
   configPath: string | undefined,
@@ -1203,6 +1556,9 @@ async function runTestModes(
     clean: boolean;
     showCoverage: boolean;
     verbose: boolean;
+    jobs: number;
+    buildJobs: number;
+    runJobs: number;
     coverage?: boolean;
     browser?: string;
   },
@@ -1214,11 +1570,45 @@ async function runTestModes(
   fuzzOverrides: FuzzOverrides,
 ): Promise<void> {
   await ensureWebBrowsersReady(configPath, modes, runFlags.browser);
-  const modeSummaryTotal = resolveConfiguredModeTotal(configPath);
+  const modeSummaryTotal = Math.max(modes.length, 1);
   const fileSummaryTotal = await resolveConfiguredFileTotal(
     configPath,
     selectors,
   );
+  if (runFlags.jobs > 1) {
+    if (modes.length > 1) {
+      const failed = await runTestMatrixParallel(
+        runFlags,
+        configPath,
+        selectors,
+        modes,
+        buildFeatureToggles,
+        modeSummaryTotal,
+        fileSummaryTotal,
+        fuzzEnabled,
+        fuzzOverrides,
+      );
+      process.exit(failed ? 1 : 0);
+      return;
+    }
+    let failed = false;
+    for (const modeName of modes) {
+      const modeFailed = await runTestSingleParallel(
+        runFlags,
+        configPath,
+        selectors,
+        buildFeatureToggles,
+        modeSummaryTotal,
+        fileSummaryTotal,
+        fuzzEnabled,
+        fuzzOverrides,
+        modeName,
+      );
+      if (modeFailed) failed = true;
+    }
+    process.exit(failed ? 1 : 0);
+    return;
+  }
   if (modes.length > 1) {
     const failed = await runTestMatrix(
       runFlags,
@@ -1296,6 +1686,9 @@ async function runTestMatrix(
     clean: boolean;
     showCoverage: boolean;
     verbose: boolean;
+    jobs: number;
+    buildJobs: number;
+    runJobs: number;
     coverage?: boolean;
   },
   configPath: string | undefined,
@@ -1464,6 +1857,27 @@ async function runFuzzModes(
   rawArgs: string[],
 ): Promise<void> {
   const overrides = resolveFuzzOverrides(rawArgs, "fuzz");
+  const { jobs, buildJobs, runJobs } = resolveFuzzParallelJobs(rawArgs);
+  const clean = rawArgs.includes("--clean");
+  if (jobs > 1) {
+    const results = await runFuzzMatrixResultsParallel(
+      configPath,
+      selectors,
+      modes,
+      overrides,
+      jobs,
+      buildJobs,
+      runJobs,
+      clean,
+    );
+    const reporterSession = await createRunReporter(configPath);
+    reporterSession.reporter.onFuzzComplete?.(
+      buildFuzzCompleteEvent(results, modes),
+    );
+    reporterSession.reporter.flush?.();
+    process.exit(results.some(hasFuzzFailures) ? 1 : 0);
+    return;
+  }
   const reporterSession = await createRunReporter(configPath);
   const results = await runFuzzMatrixResults(
     configPath,
@@ -1477,6 +1891,586 @@ async function runFuzzModes(
   );
   reporterSession.reporter.flush?.();
   process.exit(results.some(hasFuzzFailures) ? 1 : 0);
+}
+
+async function runRuntimeSingleParallel(
+  runFlags: {
+    snapshot: boolean;
+    createSnapshots: boolean;
+    overwriteSnapshots: boolean;
+    clean: boolean;
+    showCoverage: boolean;
+    verbose: boolean;
+    jobs: number;
+    buildJobs: number;
+    runJobs: number;
+    coverage?: boolean;
+    browser?: string;
+  },
+  configPath: string | undefined,
+  selectors: string[],
+  modeName: string | undefined,
+  modeSummaryTotal: number,
+  fileSummaryTotal: number,
+): Promise<boolean> {
+  const files = await resolveSelectedFiles(configPath, selectors);
+  if (!files.length) {
+    throw await buildNoTestFilesMatchedError(configPath, selectors);
+  }
+  const reporterSession = await createRunReporter(
+    configPath,
+    undefined,
+    modeName,
+  );
+  const reporter = reporterSession.reporter;
+  const snapshotEnabled = runFlags.snapshot !== false;
+  reporter.onRunStart?.({
+    runtimeName: reporterSession.runtimeName,
+    clean: runFlags.clean,
+    verbose: runFlags.verbose,
+    snapshotEnabled,
+    createSnapshots: runFlags.createSnapshots,
+  });
+  const buildCommandsByFile = await previewBuildCommands(
+    configPath,
+    selectors,
+    modeName,
+    {},
+  );
+  const results = new Array<RunResult>(files.length);
+  const queueDisplay = new ParallelQueueDisplay(!runFlags.clean);
+  const runLimit = createAsyncLimiter(runFlags.runJobs);
+  const poolWidth = Math.max(runFlags.buildJobs, runFlags.runJobs);
+  await runOrderedPool(files, poolWidth, async (file, index) => {
+    const token = renderQueuedFileStart(queueDisplay, path.basename(file));
+    const buffered = await createBufferedReporter(configPath, modeName);
+    const result = await runLimit(() =>
+      run({ ...runFlags, clean: true }, configPath, [file], false, {
+        reporter: buffered.reporter,
+        reporterKind: buffered.reporterKind,
+        modeName,
+        emitRunComplete: false,
+        fileSummaryTotal: 1,
+        modeSummaryTotal,
+        modeSummaryExecuted: 1,
+        buildCommandsByFile: { [file]: buildCommandsByFile[file] ?? "" },
+      }),
+    );
+    buffered.reporter.flush?.();
+    results[index] = result;
+    queueDisplay.complete(token, buffered.output());
+  });
+  queueDisplay.flush();
+  const summary = aggregateRunResults(results);
+  summary.stats = applyConfiguredFileTotalToStats(
+    summary.stats,
+    fileSummaryTotal,
+  );
+  reporter.onRunComplete?.({
+    clean: runFlags.clean,
+    snapshotEnabled,
+    showCoverage: runFlags.showCoverage,
+    snapshotSummary: summary.snapshotSummary,
+    coverageSummary: summary.coverageSummary,
+    stats: summary.stats,
+    reports: summary.reports,
+    modeSummary: buildSingleModeSummary(
+      summary.stats,
+      summary.snapshotSummary,
+      modeSummaryTotal,
+    ),
+  });
+  reporter.flush?.();
+  return results.some((result) => result.failed);
+}
+
+async function runRuntimeMatrixParallel(
+  runFlags: {
+    snapshot: boolean;
+    createSnapshots: boolean;
+    overwriteSnapshots: boolean;
+    clean: boolean;
+    showCoverage: boolean;
+    verbose: boolean;
+    jobs: number;
+    buildJobs: number;
+    runJobs: number;
+    coverage?: boolean;
+  },
+  configPath: string | undefined,
+  selectors: string[],
+  modes: (string | undefined)[],
+  modeSummaryTotal: number,
+  fileSummaryTotal: number,
+): Promise<boolean> {
+  const files = await resolveSelectedFiles(configPath, selectors);
+  if (!files.length) {
+    throw await buildNoTestFilesMatchedError(configPath, selectors);
+  }
+  const reporterSession = await createRunReporter(configPath);
+  const reporter = reporterSession.reporter;
+  const snapshotEnabled = runFlags.snapshot !== false;
+  reporter.onRunStart?.({
+    runtimeName: reporterSession.runtimeName,
+    clean: runFlags.clean,
+    verbose: runFlags.verbose,
+    snapshotEnabled,
+    createSnapshots: runFlags.createSnapshots,
+  });
+  const silentReporter: TestReporter = {};
+  const modeLabels = modes.map((modeName) => modeName ?? "default");
+  const showPerModeTimes = Boolean(runFlags.verbose);
+  const duplicateSpecBasenames = resolveDuplicateSpecBasenames(files);
+  const ordered = new Array<{
+    fileName: string;
+    fileResults: RunResult[];
+    modeTimes: string[];
+  }>(files.length);
+  const queueDisplay = new ParallelQueueDisplay(!runFlags.clean);
+  const poolWidth = Math.max(
+    runFlags.jobs,
+    runFlags.buildJobs,
+    runFlags.runJobs,
+  );
+  const buildPool = new BuildWorkerPool(runFlags.buildJobs);
+  try {
+    await runOrderedPool(files, poolWidth, async (file, fileIndex) => {
+      const fileName = path.basename(file);
+      const token = renderQueuedFileStart(queueDisplay, fileName);
+      const fileResults: RunResult[] = [];
+      const modeTimes = modes.map(() => "...");
+      for (let i = 0; i < modes.length; i++) {
+        const modeName = modes[i];
+        await buildPool.buildFileMode({
+          configPath,
+          file,
+          modeName,
+        });
+        const buildInvocation = await getBuildInvocationPreview(
+          configPath,
+          file,
+          modeName,
+          {},
+        );
+        const artifactKey = resolvePerFileArtifactKey(
+          file,
+          duplicateSpecBasenames,
+        );
+        const result = await run(runFlags, configPath, [file], false, {
+          reporter: silentReporter,
+          reporterKind: "default",
+          emitRunStart: false,
+          emitRunComplete: false,
+          logFileName: `run.${artifactKey}.log.json`,
+          coverageFileName: `coverage.${artifactKey}.log.json`,
+          buildCommand: formatBuildInvocation(buildInvocation),
+          modeName,
+        });
+        modeTimes[i] = formatMatrixModeTime(result.stats.time);
+        fileResults.push(result);
+      }
+      ordered[fileIndex] = { fileName, fileResults, modeTimes };
+      queueDisplay.complete(
+        token,
+        formatMatrixFileResultLine(
+          fileName,
+          modeLabels,
+          fileResults,
+          modeTimes,
+          showPerModeTimes,
+        ) + "\n",
+      );
+    });
+  } finally {
+    await buildPool.close();
+  }
+  queueDisplay.flush();
+  const allResults: RunResult[] = [];
+  const modeState = modes.map(() => ({ failed: false, passed: false }));
+  const fileState = files.map(() => ({ failed: false, passed: false }));
+  for (let fileIndex = 0; fileIndex < ordered.length; fileIndex++) {
+    const fileResults = ordered[fileIndex]!.fileResults;
+    for (let i = 0; i < fileResults.length; i++) {
+      const result = fileResults[i]!;
+      allResults.push(result);
+      if (result.failed) modeState[i]!.failed = true;
+      else if (result.stats.passedFiles > 0) modeState[i]!.passed = true;
+    }
+    const verdict = resolveMatrixVerdict(fileResults);
+    if (verdict == "fail") fileState[fileIndex]!.failed = true;
+    else if (verdict == "ok") fileState[fileIndex]!.passed = true;
+  }
+  const summary = aggregateRunResults(allResults);
+  summary.stats = applyMatrixFileSummaryToStats(
+    summary.stats,
+    fileState,
+    fileSummaryTotal,
+  );
+  reporter.onRunComplete?.({
+    clean: runFlags.clean,
+    snapshotEnabled,
+    showCoverage: runFlags.showCoverage,
+    snapshotSummary: summary.snapshotSummary,
+    coverageSummary: summary.coverageSummary,
+    stats: summary.stats,
+    reports: summary.reports,
+    modeSummary: buildModeSummary(modeState, modeSummaryTotal),
+  });
+  reporter.flush?.();
+  return allResults.some((result) => result.failed);
+}
+
+async function runTestSingleParallel(
+  runFlags: {
+    snapshot: boolean;
+    createSnapshots: boolean;
+    overwriteSnapshots: boolean;
+    clean: boolean;
+    showCoverage: boolean;
+    verbose: boolean;
+    jobs: number;
+    buildJobs: number;
+    runJobs: number;
+    coverage?: boolean;
+    browser?: string;
+  },
+  configPath: string | undefined,
+  selectors: string[],
+  buildFeatureToggles: BuildFeatureToggles,
+  modeSummaryTotal: number,
+  fileSummaryTotal: number,
+  fuzzEnabled: boolean,
+  fuzzOverrides: FuzzOverrides,
+  modeName?: string,
+): Promise<boolean> {
+  const files = await resolveSelectedFiles(configPath, selectors);
+  if (!files.length && !fuzzEnabled) {
+    throw await buildNoTestFilesMatchedError(configPath, selectors);
+  }
+  const reporterSession = await createRunReporter(
+    configPath,
+    undefined,
+    modeName,
+  );
+  const reporter = reporterSession.reporter;
+  const snapshotEnabled = runFlags.snapshot !== false;
+  reporter.onRunStart?.({
+    runtimeName: reporterSession.runtimeName,
+    clean: runFlags.clean,
+    verbose: runFlags.verbose,
+    snapshotEnabled,
+    createSnapshots: runFlags.createSnapshots,
+  });
+  const duplicateSpecBasenames = resolveDuplicateSpecBasenames(files);
+  const results = new Array<RunResult>(files.length);
+  const queueDisplay = new ParallelQueueDisplay(!runFlags.clean);
+  const poolWidth = Math.max(
+    runFlags.jobs,
+    runFlags.buildJobs,
+    runFlags.runJobs,
+  );
+  if (files.length) {
+    const buildPool = new BuildWorkerPool(runFlags.buildJobs);
+    try {
+      await runOrderedPool(files, poolWidth, async (file, index) => {
+        const token = renderQueuedFileStart(queueDisplay, path.basename(file));
+        await buildPool.buildFileMode({
+          configPath,
+          file,
+          modeName,
+          featureToggles: buildFeatureToggles,
+        });
+        const buildInvocation = await getBuildInvocationPreview(
+          configPath,
+          file,
+          modeName,
+          buildFeatureToggles,
+        );
+        const artifactKey = resolvePerFileArtifactKey(
+          file,
+          duplicateSpecBasenames,
+        );
+        const buffered = await createBufferedReporter(configPath, modeName);
+        const result = await run(
+          { ...runFlags, clean: true },
+          configPath,
+          [file],
+          false,
+          {
+            reporter: buffered.reporter,
+            reporterKind: buffered.reporterKind,
+            emitRunComplete: false,
+            logFileName: `test.${artifactKey}.log.json`,
+            coverageFileName: `coverage.${artifactKey}.log.json`,
+            buildCommand: formatBuildInvocation(buildInvocation),
+            modeName,
+          },
+        );
+        buffered.reporter.flush?.();
+        results[index] = result;
+        queueDisplay.complete(token, buffered.output());
+      });
+    } finally {
+      await buildPool.close();
+    }
+  }
+  queueDisplay.flush();
+  const runResults = results.filter(Boolean);
+  const summary = aggregateRunResults(runResults);
+  summary.stats = applyConfiguredFileTotalToStats(
+    summary.stats,
+    fileSummaryTotal,
+  );
+  let failed = runResults.some((result) => result.failed);
+  let fuzzSummary:
+    | {
+        failed: number;
+        skipped: number;
+        total: number;
+      }
+    | undefined;
+  if (fuzzEnabled) {
+    if (reporterSession.reporterKind == "default") {
+      process.stdout.write("\n");
+    }
+    const fuzzResults = await runFuzzMatrixResultsParallel(
+      configPath,
+      selectors,
+      [modeName],
+      fuzzOverrides,
+      runFlags.jobs,
+      runFlags.buildJobs,
+      runFlags.runJobs,
+      runFlags.clean,
+    );
+    if (fuzzResults.some(hasFuzzFailures)) failed = true;
+    fuzzSummary = summarizeFuzzExecutions(fuzzResults);
+  }
+  reporter.onRunComplete?.({
+    clean: runFlags.clean,
+    snapshotEnabled,
+    showCoverage: runFlags.showCoverage,
+    snapshotSummary: summary.snapshotSummary,
+    coverageSummary: summary.coverageSummary,
+    stats: summary.stats,
+    reports: summary.reports,
+    fuzzSummary,
+    modeSummary: buildSingleModeSummary(
+      summary.stats,
+      summary.snapshotSummary,
+      modeSummaryTotal,
+    ),
+  });
+  reporter.flush?.();
+  return failed;
+}
+
+async function runTestMatrixParallel(
+  runFlags: {
+    snapshot: boolean;
+    createSnapshots: boolean;
+    overwriteSnapshots: boolean;
+    clean: boolean;
+    showCoverage: boolean;
+    verbose: boolean;
+    jobs: number;
+    buildJobs: number;
+    runJobs: number;
+    coverage?: boolean;
+  },
+  configPath: string | undefined,
+  selectors: string[],
+  modes: (string | undefined)[],
+  buildFeatureToggles: BuildFeatureToggles,
+  modeSummaryTotal: number,
+  fileSummaryTotal: number,
+  fuzzEnabled: boolean,
+  fuzzOverrides: FuzzOverrides,
+): Promise<boolean> {
+  const files = await resolveSelectedFiles(configPath, selectors);
+  if (!files.length) {
+    if (!fuzzEnabled) {
+      throw await buildNoTestFilesMatchedError(configPath, selectors);
+    }
+    const fuzzFiles = await resolveSelectedFuzzFiles(configPath, selectors);
+    if (!fuzzFiles.length) {
+      throw await buildNoTestFilesMatchedError(configPath, selectors, true);
+    }
+  }
+  const reporterSession = await createRunReporter(configPath);
+  const reporter = reporterSession.reporter;
+  const snapshotEnabled = runFlags.snapshot !== false;
+  reporter.onRunStart?.({
+    runtimeName: reporterSession.runtimeName,
+    clean: runFlags.clean,
+    verbose: runFlags.verbose,
+    snapshotEnabled,
+    createSnapshots: runFlags.createSnapshots,
+  });
+  const silentReporter: TestReporter = {};
+  const modeLabels = modes.map((modeName) => modeName ?? "default");
+  const showPerModeTimes = Boolean(runFlags.verbose);
+  const duplicateSpecBasenames = resolveDuplicateSpecBasenames(files);
+  const ordered = new Array<{
+    fileName: string;
+    fileResults: RunResult[];
+    modeTimes: string[];
+  }>(files.length);
+  const queueDisplay = new ParallelQueueDisplay(!runFlags.clean);
+  const poolWidth = Math.max(
+    runFlags.jobs,
+    runFlags.buildJobs,
+    runFlags.runJobs,
+  );
+  const buildPool = new BuildWorkerPool(runFlags.buildJobs);
+  try {
+    await runOrderedPool(files, poolWidth, async (file, fileIndex) => {
+      const fileName = path.basename(file);
+      const token = renderQueuedFileStart(queueDisplay, fileName);
+      const fileResults: RunResult[] = [];
+      const modeTimes = modes.map(() => "...");
+      for (let i = 0; i < modes.length; i++) {
+        const modeName = modes[i];
+        await buildPool.buildFileMode({
+          configPath,
+          file,
+          modeName,
+          featureToggles: buildFeatureToggles,
+        });
+        const buildInvocation = await getBuildInvocationPreview(
+          configPath,
+          file,
+          modeName,
+          buildFeatureToggles,
+        );
+        const artifactKey = resolvePerFileArtifactKey(
+          file,
+          duplicateSpecBasenames,
+        );
+        const result = await run(runFlags, configPath, [file], false, {
+          reporter: silentReporter,
+          reporterKind: "default",
+          emitRunStart: false,
+          emitRunComplete: false,
+          logFileName: `test.${artifactKey}.log.json`,
+          coverageFileName: `coverage.${artifactKey}.log.json`,
+          buildCommand: formatBuildInvocation(buildInvocation),
+          modeName,
+        });
+        modeTimes[i] = formatMatrixModeTime(result.stats.time);
+        fileResults.push(result);
+      }
+      ordered[fileIndex] = { fileName, fileResults, modeTimes };
+      queueDisplay.complete(
+        token,
+        formatMatrixFileResultLine(
+          fileName,
+          modeLabels,
+          fileResults,
+          modeTimes,
+          showPerModeTimes,
+        ) + "\n",
+      );
+    });
+  } finally {
+    await buildPool.close();
+  }
+  queueDisplay.flush();
+  const allResults: RunResult[] = [];
+  const modeState = modes.map(() => ({ failed: false, passed: false }));
+  const fileState = files.map(() => ({ failed: false, passed: false }));
+  for (let fileIndex = 0; fileIndex < ordered.length; fileIndex++) {
+    const entry = ordered[fileIndex]!;
+    for (let i = 0; i < entry.fileResults.length; i++) {
+      const result = entry.fileResults[i]!;
+      allResults.push(result);
+      if (result.failed) modeState[i]!.failed = true;
+      else if (result.stats.passedFiles > 0) modeState[i]!.passed = true;
+    }
+    const verdict = resolveMatrixVerdict(entry.fileResults);
+    if (verdict == "fail") fileState[fileIndex]!.failed = true;
+    else if (verdict == "ok") fileState[fileIndex]!.passed = true;
+  }
+  const summary = aggregateRunResults(allResults);
+  summary.stats = applyMatrixFileSummaryToStats(
+    summary.stats,
+    fileState,
+    fileSummaryTotal,
+  );
+  let failed = allResults.some((result) => result.failed);
+  let fuzzSummary:
+    | {
+        failed: number;
+        skipped: number;
+        total: number;
+      }
+    | undefined;
+  if (fuzzEnabled) {
+    if (reporterSession.reporterKind == "default") {
+      process.stdout.write("\n");
+    }
+    const fuzzResults = await runFuzzMatrixResultsParallel(
+      configPath,
+      selectors,
+      modes,
+      fuzzOverrides,
+      runFlags.jobs,
+      runFlags.buildJobs,
+      runFlags.runJobs,
+      runFlags.clean,
+    );
+    if (fuzzResults.some(hasFuzzFailures)) failed = true;
+    fuzzSummary = summarizeFuzzExecutions(fuzzResults);
+  }
+  reporter.onRunComplete?.({
+    clean: runFlags.clean,
+    snapshotEnabled,
+    showCoverage: runFlags.showCoverage,
+    snapshotSummary: summary.snapshotSummary,
+    coverageSummary: summary.coverageSummary,
+    stats: summary.stats,
+    reports: summary.reports,
+    fuzzSummary,
+    modeSummary: buildModeSummary(modeState, modeSummaryTotal),
+  });
+  reporter.flush?.();
+  return failed;
+}
+
+async function runFuzzMatrixResultsParallel(
+  configPath: string | undefined,
+  selectors: string[],
+  modes: (string | undefined)[],
+  overrides: FuzzOverrides,
+  jobs: number,
+  buildJobs: number,
+  runJobs: number,
+  clean: boolean,
+): Promise<FuzzResult[]> {
+  const files = await resolveSelectedFuzzFiles(configPath, selectors);
+  if (!files.length) {
+    throw new Error(
+      `No fuzz files matched: ${selectors.length ? selectors.join(", ") : "configured input patterns"}`,
+    );
+  }
+  const ordered = new Array<FuzzResult[]>(files.length);
+  const queueDisplay = new ParallelQueueDisplay(!clean);
+  const poolWidth = Math.max(jobs, buildJobs, runJobs);
+  await runOrderedPool(files, poolWidth, async (file, index) => {
+    const token = renderQueuedFileStart(queueDisplay, path.basename(file));
+    const fileResults: FuzzResult[] = [];
+    for (const modeName of modes) {
+      const modeResults = await fuzz(configPath, [file], modeName, overrides);
+      fileResults.push(...modeResults);
+    }
+    ordered[index] = fileResults;
+    const buffered = await createBufferedReporter(configPath);
+    buffered.reporter.onFuzzFileComplete?.({ file, results: fileResults });
+    buffered.reporter.flush?.();
+    queueDisplay.complete(token, buffered.output());
+  });
+  queueDisplay.flush();
+  return ordered.flat();
 }
 
 async function runFuzzMatrixResults(
@@ -1620,6 +2614,24 @@ function renderMatrixFileResult(
   liveMatrix: boolean,
   showPerModeTimes: boolean,
 ): void {
+  const line = formatMatrixFileResultLine(
+    file,
+    modes,
+    results,
+    modeTimes,
+    showPerModeTimes,
+  );
+  if (liveMatrix) clearLiveLine();
+  process.stdout.write(line + "\n");
+}
+
+function formatMatrixFileResultLine(
+  file: string,
+  modes: string[],
+  results: RunResult[],
+  modeTimes: string[],
+  showPerModeTimes: boolean,
+): string {
   const verdict = resolveMatrixVerdict(results);
   const badge =
     verdict == "fail"
@@ -1637,9 +2649,7 @@ function renderMatrixFileResult(
     : failedModes.length
       ? ` ${chalk.dim(`(failed: ${failedModes.join(", ")})`)}`
       : "";
-  const line = `${badge} ${file} ${chalk.dim(timingText)}${suffix}`;
-  if (liveMatrix) clearLiveLine();
-  process.stdout.write(line + "\n");
+  return `${badge} ${file} ${chalk.dim(timingText)}${suffix}`;
 }
 
 function resolveMatrixVerdict(results: RunResult[]): "fail" | "ok" | "skip" {

--- a/cli/reporters/default.ts
+++ b/cli/reporters/default.ts
@@ -186,7 +186,17 @@ class DefaultReporter implements TestReporter {
       this.renderVerboseState();
       return;
     }
-    if (this.verboseMode || !this.canRewriteLine()) {
+    if (!this.verboseMode) {
+      if (!this.canRewriteLine()) {
+        this.context.stdout.write(`${this.badgeRunning()} ${event.file}\n`);
+        return;
+      }
+      this.clearRenderedBlock();
+      this.context.stdout.write(`${this.badgeRunning()} ${event.file}`);
+      this.renderedLines = 1;
+      return;
+    }
+    if (!this.canRewriteLine()) {
       this.context.stdout.write(`${this.badgeRunning()} ${event.file}\n`);
       return;
     }
@@ -217,6 +227,7 @@ class DefaultReporter implements TestReporter {
 
   onSuiteStart(event: ProgressEvent): void {
     if (this.cleanMode) return;
+    if (!this.verboseMode) return;
     const depth = Math.max(event.depth, 0);
     if (this.verboseMode && this.canRewriteLine()) {
       if (this.currentFile !== event.file) return;
@@ -242,6 +253,7 @@ class DefaultReporter implements TestReporter {
 
   onSuiteEnd(event: ProgressEvent): void {
     if (this.cleanMode) return;
+    if (!this.verboseMode) return;
     const depth = Math.max(event.depth, 0);
     const verdict = String(event.verdict ?? "none");
     if (this.verboseMode && this.canRewriteLine()) {
@@ -320,10 +332,7 @@ class DefaultReporter implements TestReporter {
       renderFailedSuites(event.stats.failedEntries);
     }
     if (event.snapshotEnabled) {
-      renderSnapshotSummary(
-        event.snapshotSummary,
-        this.hasRenderedTestFiles || this.hasRenderedFuzzFiles,
-      );
+      renderSnapshotSummary(event.snapshotSummary, true);
     }
     if (event.coverageSummary.enabled) {
       renderCoverageSummary(event.coverageSummary);

--- a/cli/reporters/default.ts
+++ b/cli/reporters/default.ts
@@ -320,7 +320,10 @@ class DefaultReporter implements TestReporter {
       renderFailedSuites(event.stats.failedEntries);
     }
     if (event.snapshotEnabled) {
-      renderSnapshotSummary(event.snapshotSummary, !this.hasRenderedFuzzFiles);
+      renderSnapshotSummary(
+        event.snapshotSummary,
+        this.hasRenderedTestFiles || this.hasRenderedFuzzFiles,
+      );
     }
     if (event.coverageSummary.enabled) {
       renderCoverageSummary(event.coverageSummary);
@@ -721,6 +724,7 @@ function renderStandaloneFuzzTotals(event: FuzzCompleteEvent): void {
 type SummaryLayout = {
   failedWidth: number;
   skippedWidth: number;
+  totalWidth: number;
 };
 
 function createSummaryLayout(
@@ -744,6 +748,11 @@ function createSummaryLayout(
         summary ? `${summary.skipped} skipped`.length : 0,
       ),
     ),
+    totalWidth: Math.max(
+      ...summaries.map((summary) =>
+        summary ? `${summary.total} total`.length : 0,
+      ),
+    ),
   };
 }
 
@@ -757,13 +766,12 @@ function renderSummaryLine(
   layout: SummaryLayout = {
     failedWidth: `${summary.failed} failed`.length,
     skippedWidth: `${summary.skipped} skipped`.length,
+    totalWidth: `${summary.total} total`.length,
   },
 ): void {
   const failedText = `${summary.failed} failed`;
   const skippedText = `${summary.skipped} skipped`;
-  const totalText = `${" ".repeat(
-    Math.max(0, layout.skippedWidth - skippedText.length),
-  )}${summary.total} total`;
+  const totalText = `${summary.total} total`;
   process.stdout.write(chalk.bold(label.padEnd(9)));
   process.stdout.write(
     summary.failed
@@ -773,7 +781,7 @@ function renderSummaryLine(
   process.stdout.write(", ");
   process.stdout.write(chalk.gray(skippedText.padStart(layout.skippedWidth)));
   process.stdout.write(", ");
-  process.stdout.write(totalText + "\n");
+  process.stdout.write(totalText.padStart(layout.totalWidth) + "\n");
 }
 
 function renderCoverageSummary(summary: {

--- a/cli/reporters/default.ts
+++ b/cli/reporters/default.ts
@@ -689,7 +689,10 @@ function renderTotals(
   }
 
   process.stdout.write(
-    chalk.bold("Time:".padEnd(9)) + formatTime(stats.time) + "\n",
+    chalk.bold("Time:".padEnd(9)) +
+      formatTime(stats.time) +
+      chalk.dim(` (${formatTime(event.buildTime)} build)`) +
+      "\n",
   );
 }
 
@@ -726,7 +729,10 @@ function renderStandaloneFuzzTotals(event: FuzzCompleteEvent): void {
   renderSummaryLine("Suites:", event.suiteSummary, layout);
   renderSummaryLine("Modes:", event.modeSummary, layout);
   process.stdout.write(
-    chalk.bold("Time:".padEnd(9)) + formatTime(event.time) + "\n",
+    chalk.bold("Time:".padEnd(9)) +
+      formatTime(event.time) +
+      chalk.dim(` (${formatTime(event.buildTime)} build)`) +
+      "\n",
   );
 }
 

--- a/cli/reporters/tap.ts
+++ b/cli/reporters/tap.ts
@@ -79,6 +79,7 @@ class TapReporter implements TestReporter {
       ...collectFuzzTapPoints({
         results: event.results,
         time: event.results.reduce((sum, item) => sum + item.time, 0),
+        buildTime: event.results.reduce((sum, item) => sum + item.buildTime, 0),
         fuzzingSummary: { failed: 0, skipped: 0, total: 0 },
         suiteSummary: { failed: 0, skipped: 0, total: 0 },
         modeSummary: { failed: 0, skipped: 0, total: 0 },

--- a/cli/reporters/types.ts
+++ b/cli/reporters/types.ts
@@ -86,6 +86,7 @@ export type RunCompleteEvent = {
   clean: boolean;
   snapshotEnabled: boolean;
   showCoverage: boolean;
+  buildTime: number;
   snapshotSummary: SnapshotSummary;
   coverageSummary: CoverageSummary;
   stats: RunStats;
@@ -130,12 +131,16 @@ export type FuzzResult = {
   crashFiles: string[];
   seed: number;
   time: number;
+  buildTime: number;
+  buildStartedAt: number;
+  buildFinishedAt: number;
   fuzzers: FuzzerRunResult[];
 };
 
 export type FuzzCompleteEvent = {
   results: FuzzResult[];
   time: number;
+  buildTime: number;
   fuzzingSummary: {
     failed: number;
     skipped: number;

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "as-test.config.schema.json",
     "index.ts"
   ],
-  "homepage": "https://github.com/JairusSW/as-test#readme",
+  "homepage": "https://docs.jairus.dev/as-test",
   "keywords": [
     "assemblyscript",
     "testing",


### PR DESCRIPTION
This PR adds the ability for tests to both run and be built in parallel.
It changes a few things:
1. Adds several flags: `--parallel`, `--jobs <n>`, `--build-jobs <n>`, `--run-jobs <n>`
2. Instead of calling `asc ...`, it invokes `asc()` which reduces overhead
